### PR TITLE
fix(update-todo): remap description to desc, normalize inputSchema to snake_case

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,16 @@ Do not use custom CSS classes. Use Vuetify component props, slots, and the `:dee
 
 Global Vuetify component defaults are set in `config/vuetify.ts`. `VBtn` defaults to `variant: 'plain'`, `VTextField` to `variant: 'outlined'`, `density: 'compact'`. Override per-component as needed.
 
+### MCP tool development workflow
+
+After implementing a bug fix or new feature, run `@agent-code-improvement-advisor review this branch` to catch readability, performance, and best-practice issues before committing.
+
+Each MCP tool has a paired test task and branch in tickup (format: `write-a-test-for-the-'<tool-name>'-mcp-tool`). When fixing a bug in an MCP tool, switch to that tool's test branch and include the fix there. Bug fixes and tests for the same tool ship together. Every bug fix must have a regression test that would have caught it.
+
+To find in-progress MCP work: use `search_todos` via the tickup MCP (`mcp__tickup-ewrmrye0m-greg-fields-projects__search_todos`) with keyword `"MCP"`. The parent epic is todo #2108 "implement mcp tool tests".
+
+**Known field gotcha**: the `Todos` DB column for a todo's description is `desc`, not `description`. `objectToSnake` does not rename this. Any MCP tool that accepts a `description` input must manually remap it to `desc` before the Supabase call. The `update-todo` tool has this fix; watch for the same issue in future tools.
+
 ### E2e test conventions
 
 - Tests import `test` and `expect` from `e2e/fixtures/index.ts` (not from `@playwright/test` directly) to get the `listAPI` fixture.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ Global Vuetify component defaults are set in `config/vuetify.ts`. `VBtn` default
 
 After implementing a bug fix or new feature, run `@agent-code-improvement-advisor review this branch` to catch readability, performance, and best-practice issues before committing.
 
+When creating a PR, set the base branch to the parent task's branch (not `main`). Look up the current task in tickup, find its `parentId`, then use that parent task's `githubBranchName` as the PR target.
+
 Each MCP tool has a paired test task and branch in tickup (format: `write-a-test-for-the-'<tool-name>'-mcp-tool`). When fixing a bug in an MCP tool, switch to that tool's test branch and include the fix there. Bug fixes and tests for the same tool ship together. Every bug fix must have a regression test that would have caught it.
 
 To find in-progress MCP work: use `search_todos` via the tickup MCP (`mcp__tickup-ewrmrye0m-greg-fields-projects__search_todos`) with keyword `"MCP"`. The parent epic is todo #2108 "implement mcp tool tests".

--- a/server/mcp/tools/todo/update-todo.ts
+++ b/server/mcp/tools/todo/update-todo.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { objectToSnake } from 'ts-case-convert';
 import { mcpSupabaseClient, mcpUserId } from '../../utils/auth';
 import { TaskService } from '../../../utils/tasks';
 
@@ -12,30 +11,35 @@ export default defineMcpTool({
         description: z.string().optional(),
         status: z.string().optional(),
         priority_lev: z.enum(['high', 'medium', 'low']).optional(),
-        listId: z.string().optional(),
-        parentId: z.union([z.string(), z.number()]).optional().describe('Parent todo ID for subtasks'),
-        dueDate: z.string().nullable().optional(),
-        completedDate: z.string().nullable().optional(),
-        notificationDateTime: z.string().nullable().optional(),
-        notificationSent: z.boolean().optional(),
+        list_id: z.string().optional(),
+        parent_id: z
+            .union([z.string(), z.number()])
+            .optional()
+            .describe('Parent todo ID for subtasks'),
+        due_date: z.string().nullable().optional(),
+        completed_date: z.string().nullable().optional(),
+        notification_date_time: z.string().nullable().optional(),
+        notification_sent: z.boolean().optional(),
         order: z.number().optional(),
-        githubBranchName: z.string().nullable().optional(),
+        github_branch_name: z.string().nullable().optional(),
     },
     handler: async (args) => {
         const event = useEvent();
         await mcpUserId(event);
 
-        const { id, ...updateFields } = args;
+        const { id, description, ...rest } = args;
 
-        // Coerce parentId to number if it's a string
-        if (updateFields.parentId !== undefined) {
-            updateFields.parentId = typeof updateFields.parentId === 'string'
-                ? parseInt(updateFields.parentId, 10)
-                : updateFields.parentId;
+        // Coerce parent_id to number if it's a string
+        if (rest.parent_id !== undefined) {
+            rest.parent_id =
+                typeof rest.parent_id === 'string' ? parseInt(rest.parent_id, 10) : rest.parent_id;
         }
 
-        // Convert camelCase to snake_case
-        const updates = objectToSnake(updateFields) as Partial<Task>;
+        // DB column is `desc`, not `description`
+        const updates: Partial<Task> = rest as unknown as Partial<Task>;
+        if (description !== undefined) {
+            (updates as Record<string, unknown>).desc = description;
+        }
 
         const supabase = await mcpSupabaseClient(event);
         const tasks = new TaskService(supabase);
@@ -47,8 +51,9 @@ export default defineMcpTool({
             return [
                 {
                     isError: true,
-                    message: (error as unknown as Record<string, unknown>).message || 'Update failed',
-                }
+                    message:
+                        (error as unknown as Record<string, unknown>).message || 'Update failed',
+                },
             ];
         }
 
@@ -57,7 +62,7 @@ export default defineMcpTool({
                 {
                     isError: true,
                     message: 'Todo not found',
-                }
+                },
             ];
         }
 

--- a/test/unit/mcp/update-todo.test.ts
+++ b/test/unit/mcp/update-todo.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect } from 'vitest';
 import { mcpTest } from '../fixtures/mcp';
 
+function parseToolContent(result: unknown): unknown {
+    const items = (result as Record<string, unknown>).content as Record<string, unknown>[];
+    return JSON.parse(items[0].text as string);
+}
+
+function firstItem(result: unknown): Record<string, unknown> {
+    const parsed = parseToolContent(result);
+    return Array.isArray(parsed) ? parsed[0] : (parsed as Record<string, unknown>);
+}
+
 describe('update_todo MCP tool', () => {
     mcpTest('should list tools and find update_todo', async ({ client }) => {
         const result = await client.listTools();
@@ -9,7 +19,9 @@ describe('update_todo MCP tool', () => {
 
         const updateTodoTool = result.tools.find((t: { name: string }) => t.name === 'update_todo');
         expect(updateTodoTool).toBeDefined();
-        expect(updateTodoTool?.description).toBe('Update a todo. Any provided fields are merged into the existing todo.');
+        expect(updateTodoTool?.description).toBe(
+            'Update a todo. Any provided fields are merged into the existing todo.',
+        );
     });
 
     mcpTest('should have correct tool input schema', async ({ client }) => {
@@ -19,21 +31,17 @@ describe('update_todo MCP tool', () => {
         expect(updateTodoTool?.inputSchema).toBeDefined();
         const schema = updateTodoTool?.inputSchema as Record<string, unknown>;
 
-        // Should accept todo ID
         expect(schema.properties).toBeDefined();
         const properties = schema.properties as Record<string, unknown>;
         expect(properties.id).toBeDefined();
-
-        // Should accept optional fields
         expect(properties.name).toBeDefined();
         expect(properties.status).toBeDefined();
         expect(properties.description).toBeDefined();
-        expect(properties.priority).toBeDefined();
+        expect(properties.priority_lev).toBeDefined();
     });
 
     mcpTest('should call update_todo tool without error', async ({ client }) => {
-        // Test calling the tool with a valid structure
-        // Note: This will fail with "todo not found" but that's OK - we're testing the tool is callable
+        // Note: This will fail with "todo not found" but that's OK — testing the tool is callable
         const result = await client.callTool({
             name: 'update_todo',
             arguments: {
@@ -42,95 +50,72 @@ describe('update_todo MCP tool', () => {
             },
         });
 
-        // Should have content (either success or error response)
         expect(result.content).toBeDefined();
         expect(Array.isArray(result.content)).toBe(true);
     });
 
     mcpTest('should accept parent_id parameter in update_todo', async ({ client }) => {
-        // Create parent todo
         const parentResult = await client.callTool({
             name: 'create_todo',
-            arguments: {
-                name: 'Parent Todo',
-            },
+            arguments: { name: 'Parent Todo' },
         });
-        expect(parentResult.content).toBeDefined();
-        const parentContent = Array.isArray(parentResult.content) && parentResult.content[0];
-        const parentTodos = JSON.parse((parentContent as Record<string, unknown>).text as string);
-        const parentId = parentTodos[0].id;
+        const parentTodo = firstItem(parentResult);
+        const parentId = parentTodo.id;
 
-        // Create child todo with parent_id already set
         const childResult = await client.callTool({
             name: 'create_todo',
-            arguments: {
-                name: 'Child Todo',
-                parent_id: String(parentId),
-            },
+            arguments: { name: 'Child Todo', parent_id: String(parentId) },
         });
-        expect(childResult.content).toBeDefined();
-        const childContent = Array.isArray(childResult.content) && childResult.content[0];
-        const childTodos = JSON.parse((childContent as Record<string, unknown>).text as string);
-        const childTodo = childTodos[0];
-
-        // Verify child has parent_id in creation response
+        const childTodo = firstItem(childResult);
         expect(childTodo.parent_id).toBe(parentId);
 
-        // Test that update_todo accepts parent_id without validation error
-        // Full E2E verification deferred - API endpoint needs auth investigation
         const updateResult = await client.callTool({
             name: 'update_todo',
-            arguments: {
-                id: String(childTodo.id),
-                parentId: String(parentId),
-            },
+            arguments: { id: String(childTodo.id), parent_id: String(parentId) },
         });
 
-        expect(updateResult.content).toBeDefined();
-        const contentArray = updateResult.content as unknown[];
-        const content = contentArray[0] as Record<string, unknown>;
-        const text = content.text as string;
-
-        // Should not have schema validation error (the key requirement)
+        const text = (updateResult.content as Record<string, unknown>[])[0].text as string;
         expect(text).not.toContain('Input validation error');
         expect(text).not.toContain('invalid_type');
     });
 
-    mcpTest('should accept priority parameter in update_todo', async ({ client }) => {
-        // Create a todo
+    mcpTest('should persist description field when updating a todo', async ({ client }) => {
         const createResult = await client.callTool({
             name: 'create_todo',
-            arguments: {
-                name: 'Priority Test Todo',
-            },
+            arguments: { name: 'Description Test Todo' },
         });
-        expect(createResult.content).toBeDefined();
-        const createContent = Array.isArray(createResult.content) && createResult.content[0];
-        const createdTodos = JSON.parse((createContent as Record<string, unknown>).text as string);
-        const todoId = createdTodos[0].id;
+        const created = firstItem(createResult);
 
-        // Test that update_todo accepts priority without validation error
         const updateResult = await client.callTool({
             name: 'update_todo',
-            arguments: {
-                id: String(todoId),
-                priority: 'high',
-            },
+            arguments: { id: String(created.id), description: 'A meaningful description' },
         });
 
-        expect(updateResult.content).toBeDefined();
-        const contentArray = updateResult.content as unknown[];
-        const content = contentArray[0] as Record<string, unknown>;
-        const text = content.text as string;
+        const text = (updateResult.content as Record<string, unknown>[])[0].text as string;
+        expect(text).not.toContain('schema cache');
+        expect(text).not.toContain('isError');
 
-        // Should not have schema validation error
+        const updated = firstItem(updateResult);
+        expect(updated.desc).toBe('A meaningful description');
+    });
+
+    mcpTest('should accept priority_lev parameter in update_todo', async ({ client }) => {
+        const createResult = await client.callTool({
+            name: 'create_todo',
+            arguments: { name: 'Priority Test Todo' },
+        });
+        const created = firstItem(createResult);
+
+        const updateResult = await client.callTool({
+            name: 'update_todo',
+            arguments: { id: String(created.id), priority_lev: 'high' },
+        });
+
+        const text = (updateResult.content as Record<string, unknown>[])[0].text as string;
         expect(text).not.toContain('Input validation error');
         expect(text).not.toContain('invalid_type');
 
-        // Verify priority is in the response
-        const updatedData = JSON.parse(text);
-        // Response could be array or object
-        const updatedTodo = Array.isArray(updatedData) ? updatedData[0] : updatedData;
-        expect(updatedTodo.priority).toBe('high');
+        const updated = firstItem(updateResult);
+        expect(updated.priority_lev).toBe('high');
     });
 });


### PR DESCRIPTION
## Summary

- **Bug fix**: `description` input was silently dropped on update — `objectToSnake` doesn't rename it to the `desc` DB column. Added explicit remap before the Supabase call.
- **Schema cleanup**: normalized all `inputSchema` fields to snake_case (`listId` → `list_id`, `dueDate` → `due_date`, etc.) to match `create-todo` and remove the now-redundant `objectToSnake` call.
- **Tests**: added regression test for `description` persistence; fixed priority test to use `priority_lev` (correct field); extracted `parseToolContent`/`firstItem` helpers to remove repeated cast boilerplate.
- **Docs**: added bug fix + code review workflow notes to `CLAUDE.md`.

## Test plan

- [x] `pnpm vitest run --project=unit test/unit/mcp/update-todo.test.ts` — 6/6 pass
- [ ] Manually verify `update_todo` with `description` field persists to DB via MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)