### PR TITLE
Unit tests for stores/helpers.ts factory functions

### DIFF
--- a/test/unit/stores/helpers.test.ts
+++ b/test/unit/stores/helpers.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { createNewListState, createNewTodoState } from '../../../app/stores/helpers';
+
+describe('createNewListState', () => {
+    it('returns correct default shape', () => {
+        const list = createNewListState();
+        expect(list.name).toBe('');
+        expect(list.todos).toEqual([]);
+        expect(list.icon).toBe('mdi-format-list-bulleted');
+        expect(list.listType).toBe('simple');
+    });
+
+    it('returns independent objects on each call', () => {
+        const a = createNewListState();
+        const b = createNewListState();
+        a.todos.push({ name: 'x' } as never);
+        expect(b.todos).toHaveLength(0);
+    });
+});
+
+describe('createNewTodoState', () => {
+    it('returns correct default shape', () => {
+        const todo = createNewTodoState();
+        expect(todo.name).toBe('');
+        expect(todo.status).toBe('Open');
+        expect(todo.desc).toBe('');
+        expect(todo.edit).toBe(false);
+        expect(todo.color).toBe('#87909e');
+        expect(todo.links).toEqual([]);
+        expect(todo.attachments).toEqual([]);
+        expect(todo.priorityLev).toBe('');
+    });
+
+    it('returns independent objects on each call', () => {
+        const a = createNewTodoState();
+        const b = createNewTodoState();
+        a.links.push('http://example.com');
+        expect(b.links).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Summary
- Adds vitest unit tests for `createNewListState` and `createNewTodoState` in `app/stores/helpers.ts`
- Tests cover default shape and reference isolation (independent objects per call)

## Test plan
- [ ] `pnpm vitest --project=unit test/unit/stores/helpers.test.ts` passes (4/4)

Closes tickup task #3273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)