### PR TITLE
Search within a list

### DIFF
--- a/app/components/Search/Results.vue
+++ b/app/components/Search/Results.vue
@@ -56,7 +56,7 @@ function formatDate(dateStr: string) {
 
     <v-list v-else class="px-3 flex-grow-1 bg-transparent" style="overflow-y: auto">
         <v-list-item
-            v-for="item in store.results"
+            v-for="item in store.filteredResults"
             :key="item.id"
             :to="`/todo/${item.id}`"
             rounded="xl"

--- a/app/components/Search/index.vue
+++ b/app/components/Search/index.vue
@@ -82,6 +82,22 @@ onMounted(() => {
                         autofocus
                         clearable
                     />
+                    <div
+                        v-if="searchStore.availableLists.length"
+                        class="d-flex flex-wrap ga-2 mt-2"
+                    >
+                        <v-chip
+                            v-for="list in searchStore.availableLists"
+                            :key="list.id"
+                            size="small"
+                            :variant="searchStore.selectedListId === list.id ? 'flat' : 'tonal'"
+                            :color="searchStore.selectedListId === list.id ? 'primary' : undefined"
+                            label
+                            @click="searchStore.selectList(list.id!)"
+                        >
+                            {{ list.name }}
+                        </v-chip>
+                    </div>
                 </v-card-item>
 
                 <v-divider />

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -42,6 +42,20 @@ onMounted(() => {
                 rounded="lg"
                 density="comfortable"
             />
+
+            <div v-if="searchStore.availableLists.length" class="d-flex flex-wrap ga-2 mt-3">
+                <v-chip
+                    v-for="list in searchStore.availableLists"
+                    :key="list.id"
+                    size="small"
+                    :variant="searchStore.selectedListId === list.id ? 'flat' : 'tonal'"
+                    :color="searchStore.selectedListId === list.id ? 'primary' : undefined"
+                    label
+                    @click="searchStore.selectList(list.id!)"
+                >
+                    {{ list.name }}
+                </v-chip>
+            </div>
         </div>
 
         <SearchResults :disable-status-button="true" />

--- a/app/stores/search.ts
+++ b/app/stores/search.ts
@@ -4,6 +4,25 @@ export const useSearchStore = defineStore('search', () => {
     const searchQuery = ref('');
     const results = ref<Todo[]>([]);
     const loading = ref(false);
+    const selectedListId = ref<string | null>(null);
+
+    const availableLists = computed(() => {
+        const seen = new Set<string>();
+        return results.value
+            .filter((todo) => todo.list?.id)
+            .reduce<List[]>((acc, todo) => {
+                if (!seen.has(todo.list!.id!)) {
+                    seen.add(todo.list!.id!);
+                    acc.push(todo.list!);
+                }
+                return acc;
+            }, []);
+    });
+
+    const filteredResults = computed(() => {
+        if (!selectedListId.value) return results.value;
+        return results.value.filter((todo) => todo.listId === selectedListId.value);
+    });
 
     async function search() {
         loading.value = true;
@@ -21,7 +40,21 @@ export const useSearchStore = defineStore('search', () => {
     }
     const debouncedSearch = useDebounceFn(search, 500);
 
-    return { results, loading, search, debouncedSearch, searchQuery };
+    function selectList(listId: string | null) {
+        selectedListId.value = selectedListId.value === listId ? null : listId;
+    }
+
+    return {
+        results,
+        filteredResults,
+        availableLists,
+        selectedListId,
+        loading,
+        search,
+        debouncedSearch,
+        searchQuery,
+        selectList,
+    };
 });
 
 if (import.meta.hot) {


### PR DESCRIPTION
## Summary
- Adds `selectedListId`, `availableLists`, and `filteredResults` to the search store
- Shows list filter chips above results when results span multiple lists
- Clicking a chip filters results to that list; clicking again clears the filter
- Works on both mobile search page and desktop search dialog

Closes tickup task #2647.

## Test plan
- [ ] Search for a term that returns todos from multiple lists — chips appear
- [ ] Click a chip — results filter to that list
- [ ] Click the same chip again — filter clears
- [ ] Search with no results — no chips shown
- [ ] Search returning todos from one list — chip appears and toggles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now filter search results by selecting from available lists using interactive list chips.
  * Added list selection UI to both the search dialog and mobile search page.
  * Search results dynamically update to display only items from the selected list.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/proggreg/tickup/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->