### PR TITLE
Integration tests for Settings API

### DIFF
--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -176,6 +176,7 @@ export type Database = {
                     github_webhook_subscriptions: Json | null;
                     id: string;
                     push_subscriptions: Json | null;
+                    statuses: Json | null;
                     username: string | null;
                 };
                 Insert: {
@@ -184,6 +185,7 @@ export type Database = {
                     github_webhook_subscriptions?: Json | null;
                     id: string;
                     push_subscriptions?: Json | null;
+                    statuses?: Json | null;
                     username?: string | null;
                 };
                 Update: {
@@ -192,6 +194,7 @@ export type Database = {
                     github_webhook_subscriptions?: Json | null;
                     id?: string;
                     push_subscriptions?: Json | null;
+                    statuses?: Json | null;
                     username?: string | null;
                 };
                 Relationships: [];

--- a/e2e/api/settings/settings.spec.ts
+++ b/e2e/api/settings/settings.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Settings API', () => {
+    test('GET /api/settings returns current settings object', async ({ request }) => {
+        const response = await request.get('/api/settings');
+
+        expect(response.ok()).toBeTruthy();
+
+        const body = await response.json();
+        expect(body).toHaveProperty('statuses');
+        expect(Array.isArray(body.statuses)).toBeTruthy();
+    });
+
+    test('PUT /api/settings updates statuses and GET reflects the change', async ({ request }) => {
+        const updatedStatuses = [
+            { name: 'Todo', color: '#aabbcc' },
+            { name: 'Done', color: '#00ff00' },
+        ];
+
+        const putResponse = await request.put('/api/settings', {
+            data: { statuses: updatedStatuses },
+        });
+
+        expect(putResponse.ok()).toBeTruthy();
+        const putBody = await putResponse.json();
+        expect(putBody.statuses).toEqual(updatedStatuses);
+
+        const getResponse = await request.get('/api/settings');
+        expect(getResponse.ok()).toBeTruthy();
+        const getBody = await getResponse.json();
+        expect(getBody.statuses).toEqual(updatedStatuses);
+    });
+
+    test('PUT /api/settings with missing statuses field returns 400', async ({ request }) => {
+        const response = await request.put('/api/settings', {
+            data: { unknownField: 'value' },
+        });
+
+        expect(response.status()).toBe(400);
+    });
+
+    test('PUT /api/settings with non-array statuses returns 400', async ({ request }) => {
+        const response = await request.put('/api/settings', {
+            data: { statuses: 'not-an-array' },
+        });
+
+        expect(response.status()).toBe(400);
+    });
+});

--- a/server/api/settings/index.get.ts
+++ b/server/api/settings/index.get.ts
@@ -1,9 +1,23 @@
-export default defineEventHandler(async (event) => {
-    try {
-        const query = getQuery(event);
+import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server';
+import type { Database } from '~/types/database.types';
 
-        return await SettingsSchema.find({ userId: query.userId });
-    } catch (error) {
-        return error;
+export default defineEventHandler(async (event) => {
+    const supabase = await serverSupabaseClient<Database>(event);
+    const user = await serverSupabaseUser(event);
+
+    if (!user) {
+        throw createError({ statusCode: 401, message: 'Unauthorized' });
     }
+
+    const { data, error } = await supabase
+        .from('Users')
+        .select('statuses')
+        .eq('id', user.sub)
+        .single();
+
+    if (error && error.code !== 'PGRST116') {
+        throw createError({ statusCode: 500, message: 'Failed to fetch settings' });
+    }
+
+    return { statuses: data?.statuses ?? [] };
 });

--- a/server/api/settings/index.put.ts
+++ b/server/api/settings/index.put.ts
@@ -1,13 +1,27 @@
+import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server';
+import type { Database } from '~/types/database.types';
+
 export default defineEventHandler(async (event) => {
-    try {
-        const body = await readBody(event);
-        const options = { upsert: true };
-        return await SettingsSchema.updateOne(
-            { userId: body.userId },
-            { statuses: body.statuses },
-            options,
-        );
-    } catch (error) {
-        return error;
+    const supabase = await serverSupabaseClient<Database>(event);
+    const user = await serverSupabaseUser(event);
+
+    if (!user) {
+        throw createError({ statusCode: 401, message: 'Unauthorized' });
     }
+
+    const body = await readBody(event);
+
+    if (!body || !Array.isArray(body.statuses)) {
+        throw createError({ statusCode: 400, message: 'statuses must be an array' });
+    }
+
+    const { error } = await supabase
+        .from('Users')
+        .upsert({ id: user.sub, statuses: body.statuses });
+
+    if (error) {
+        throw createError({ statusCode: 500, message: 'Failed to update settings' });
+    }
+
+    return { statuses: body.statuses };
 });

--- a/supabase/migrations/20260523000000_user_statuses.sql
+++ b/supabase/migrations/20260523000000_user_statuses.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."Users"
+    ADD COLUMN IF NOT EXISTS statuses jsonb DEFAULT '[]'::jsonb;


### PR DESCRIPTION
## Summary
- Rewrote `GET /api/settings` and `PUT /api/settings` to use Supabase (previously referenced undefined `SettingsSchema` MongoDB object)
- Added `statuses` jsonb column to `Users` table via migration
- Wrote 4 integration tests covering: GET returns settings, PUT+GET round-trip, missing statuses field (400), non-array statuses (400)

## Test plan
- [x] `pnpm e2e --project=api` — all 7 API tests pass (1 skipped)
- [x] Settings GET returns `{ statuses: [] }` when no settings saved yet
- [x] Settings PUT persists statuses and GET reflects them
- [x] Invalid inputs return 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)