### PR TITLE
feat(nav): redesign mobile bottom navigation

### DIFF
--- a/app/components/App/Nav/Mobile.vue
+++ b/app/components/App/Nav/Mobile.vue
@@ -1,54 +1,173 @@
 <script setup lang="ts">
-const { smAndDown } = useDisplay();
+const dialog = useDialog();
+const route = useRoute();
 const isKeyboardOpen = ref(false);
 
 if (import.meta.client) {
     const onViewportResize = () => {
-        isKeyboardOpen.value
-            = (window.visualViewport?.height ?? window.innerHeight) < window.innerHeight * 0.75;
+        isKeyboardOpen.value =
+            (window.visualViewport?.height ?? window.innerHeight) < window.innerHeight * 0.75;
     };
     window.visualViewport?.addEventListener('resize', onViewportResize);
     onUnmounted(() => window.visualViewport?.removeEventListener('resize', onViewportResize));
 }
+
+const leftItems = [
+    { key: 'home', label: 'Home', icon: 'mdi-home-outline', iconActive: 'mdi-home', to: '/' },
+    {
+        key: 'lists',
+        label: 'Lists',
+        icon: 'mdi-format-list-bulleted',
+        iconActive: 'mdi-format-list-checks',
+        to: '/lists',
+    },
+];
+
+const rightItems = [
+    {
+        key: 'search',
+        label: 'Search',
+        icon: 'mdi-magnify',
+        iconActive: 'mdi-magnify',
+        to: '/search',
+    },
+    {
+        key: 'account',
+        label: 'Account',
+        icon: 'mdi-account-outline',
+        iconActive: 'mdi-account',
+        to: '/account',
+    },
+];
+
+function isActive(to: string) {
+    return to === '/' ? route.path === '/' : route.path.startsWith(to);
+}
 </script>
 
 <template>
-    <v-bottom-navigation
-        v-if="smAndDown"
-        grow
-        app
-        :active="!isKeyboardOpen"
-    >
-        <v-btn
-            to="/"
-            value="home"
+    <nav v-if="!isKeyboardOpen" class="mobile-nav">
+        <button
+            v-for="item in leftItems"
+            :key="item.key"
+            class="mobile-nav__tab"
+            :class="{ 'mobile-nav__tab--active': isActive(item.to) }"
+            @click="navigateTo(item.to)"
         >
-            <v-icon>mdi-home</v-icon>
-            <span>Home</span>
-        </v-btn>
+            <i
+                class="mdi mobile-nav__icon"
+                :class="isActive(item.to) && item.iconActive ? item.iconActive : item.icon"
+            />
+            <span class="mobile-nav__label">{{ item.label }}</span>
+        </button>
 
-        <v-btn
-            to="/lists"
-            value="lists"
-        >
-            <v-icon>mdi-format-list-bulleted</v-icon>
-            <span>Lists</span>
-        </v-btn>
+        <!-- Raised FAB -->
+        <div class="mobile-nav__fab-wrap">
+            <button
+                class="mobile-nav__fab"
+                @click="
+                    dialog.page = 'todo';
+                    dialog.open = true;
+                "
+            >
+                <i class="mdi mdi-plus" style="font-size: 26px" />
+            </button>
+        </div>
 
-        <v-btn
-            to="/search"
-            value="search"
+        <button
+            v-for="item in rightItems"
+            :key="item.key"
+            class="mobile-nav__tab"
+            :class="{ 'mobile-nav__tab--active': isActive(item.to) }"
+            @click="navigateTo(item.to)"
         >
-            <v-icon>mdi-magnify</v-icon>
-            <span>Search</span>
-        </v-btn>
-
-        <v-btn
-            to="/settings"
-            value="settings"
-        >
-            <v-icon>mdi-cog</v-icon>
-            <span>Settings</span>
-        </v-btn>
-    </v-bottom-navigation>
+            <i
+                class="mdi mobile-nav__icon"
+                :class="isActive(item.to) && item.iconActive ? item.iconActive : item.icon"
+            />
+            <span class="mobile-nav__label">{{ item.label }}</span>
+        </button>
+    </nav>
 </template>
+
+<style scoped>
+.mobile-nav {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 64px;
+    background: #ffffff;
+    border-top: 1px solid rgba(113, 124, 130, 0.16);
+    display: flex;
+    align-items: stretch;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+    z-index: 100;
+    /* allow FAB to overflow above */
+    overflow: visible;
+}
+
+.mobile-nav__tab {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 3px;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    color: rgba(42, 52, 57, 0.45);
+    padding: 8px 4px;
+    transition: color 0.1s;
+}
+.mobile-nav__tab--active {
+    color: #005ac2;
+}
+
+.mobile-nav__icon {
+    font-size: 22px;
+}
+
+.mobile-nav__label {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    line-height: 1;
+}
+
+/* FAB slot */
+.mobile-nav__fab-wrap {
+    flex: 1;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.mobile-nav__fab {
+    position: absolute;
+    bottom: 10px;
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    background: #005ac2;
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #ffffff;
+    cursor: pointer;
+    box-shadow:
+        0 4px 16px rgba(0, 90, 194, 0.36),
+        0 2px 6px rgba(0, 90, 194, 0.2);
+    transition:
+        opacity 0.1s,
+        transform 0.1s;
+}
+.mobile-nav__fab:hover {
+    opacity: 0.92;
+}
+.mobile-nav__fab:active {
+    transform: scale(0.95);
+}
+</style>

--- a/app/components/App/Nav/index.vue
+++ b/app/components/App/Nav/index.vue
@@ -60,8 +60,6 @@ async function signOut() {
         </v-list>
 
         <template #append>
-            <AppMenu v-if="smAndDown" />
-
             <!-- Account footer -->
             <div ref="footerEl" class="nav-account-footer">
                 <!-- Popover — opens upward -->

--- a/app/layouts/mobile.vue
+++ b/app/layouts/mobile.vue
@@ -1,71 +1,18 @@
 <script setup lang="ts">
 const colorMode = useColorMode();
-const route = useRoute();
-const dialog = useDialog();
-
-function addEventHandler() {
-    if (route.name === 'lists') {
-        dialog.value.page = 'list';
-    }
-    else if (route.name === 'index' || route.name === 'list-id') {
-        dialog.value.page = 'todo';
-    }
-
-    dialog.value.open = true;
-}
-
-const { smAndDown } = useDisplay();
-
-const showFab = computed(() => {
-    return (
-        smAndDown.value
-        && (route.name === 'lists' || route.name === 'list-id' || route.name === 'index')
-    );
-});
 </script>
 
 <template>
     <ColorScheme>
-        <v-theme-provider
-            with-background
-            :theme="colorMode.preference"
-        >
+        <v-theme-provider with-background :theme="colorMode.preference">
             <v-app>
                 <v-main>
-                    <v-container
-                        class="pa-0"
-                        fluid
-                    >
+                    <v-container class="pa-0" fluid>
                         <NuxtPage />
                         <AppNavMobile />
                     </v-container>
                 </v-main>
-                <v-btn
-                    v-if="showFab"
-                    class="new-todo-fab"
-                    rounded="pill"
-                    color="primary"
-                    prepend-icon="mdi-plus"
-                    text="New"
-                    @click="addEventHandler"
-                />
             </v-app>
         </v-theme-provider>
     </ColorScheme>
 </template>
-
-<style scoped>
-.new-todo-fab {
-    position: fixed;
-    bottom: 80px;
-    right: 20px;
-    font-size: 1rem !important;
-    font-weight: 600 !important;
-    letter-spacing: 0 !important;
-    text-transform: none !important;
-    padding: 0 24px !important;
-    height: 48px !important;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25) !important;
-    z-index: 10;
-}
-</style>


### PR DESCRIPTION
## Summary

- Replace `v-bottom-navigation` with custom fixed bottom tab bar
- Tabs: Home | Lists | [raised FAB] | Search | Account
- Center FAB opens new todo dialog
- Active tab shows filled icon variant
- Remove redundant layout-level FAB button and old `AppMenu` mobile dropdown
- Nav hidden when soft keyboard is open (visual viewport detection)

## Test plan

- [ ] Bottom nav visible on mobile layout
- [ ] Home, Lists, Search, Account tabs navigate to correct routes
- [ ] Active tab highlighted with primary colour + filled icon
- [ ] FAB opens new todo dialog
- [ ] Nav hides when keyboard is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)