### PR TITLE
feat(search): relative due dates and overdue highlighting in results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.claude/worktrees/
+
 # Created by .ignore support plugin (hsz.mobi)
 ### Node template
 # Logs

--- a/app/components/Search/Results.vue
+++ b/app/components/Search/Results.vue
@@ -8,12 +8,27 @@ const _emit = defineEmits<{
 }>();
 const { isMobile } = useDevice();
 
-function formatDate(dateStr: string) {
-    return new Date(dateStr).toLocaleDateString('en-GB', {
-        day: '2-digit',
-        month: '2-digit',
-        year: '2-digit',
-    });
+function relativeDate(dateStr: string | null | Date): string | null {
+    if (!dateStr) return null;
+    const date = new Date(dateStr);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    date.setHours(0, 0, 0, 0);
+    const diffDays = Math.round((date.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+    if (diffDays === 0) return 'Today';
+    if (diffDays === 1) return 'Tomorrow';
+    if (diffDays === -1) return 'Yesterday';
+    if (diffDays > 1) return `In ${diffDays}d`;
+    return `${Math.abs(diffDays)}d ago`;
+}
+
+function isOverdue(item: Todo): boolean {
+    if (!item.dueDate || item.status === 'Closed') return false;
+    const date = new Date(item.dueDate);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    date.setHours(0, 0, 0, 0);
+    return date.getTime() < today.getTime();
 }
 </script>
 
@@ -116,7 +131,12 @@ function formatDate(dateStr: string) {
                 >
                     {{ item.list.name }}
                 </v-chip>
-                <span class="text-caption text-disabled">{{ formatDate(item.updatedAt) }}</span>
+                <span
+                    v-if="relativeDate(item.dueDate)"
+                    class="text-caption"
+                    :style="isOverdue(item) ? 'color: #ba1b24' : undefined"
+                    :class="!isOverdue(item) ? 'text-disabled' : undefined"
+                >{{ relativeDate(item.dueDate) }}</span>
             </v-list-item-subtitle>
 
             <template

--- a/app/pages/search.vue
+++ b/app/pages/search.vue
@@ -25,7 +25,7 @@ onMounted(() => {
     <div class="d-flex flex-column h-100 pb-20">
         <div class="px-5 pt-8 pb-4 flex-shrink-0">
             <div class="d-flex align-center ga-3 mb-4">
-                <span class="text-h5 font-weight-bold">Search</span>
+                <span class="text-h5" style="font-family: 'Manrope', sans-serif; font-weight: 800">Search</span>
                 <v-chip
                     v-if="searchStore.results.length"
                     size="small"


### PR DESCRIPTION
## Summary

- Replace fixed date format with relative labels (Today / Tomorrow / Yesterday / In Nd / Nd ago) using `item.dueDate` instead of `item.updatedAt`
- Overdue todos (past due date, status not Closed) show the date in red (`#ba1b24`)
- Due date is hidden when `dueDate` is null — many todos won't have one
- Search page heading updated to use Manrope font at weight 800

## Test plan

- [ ] Search for todos with due dates in the past — confirm they show "Nd ago" in red
- [ ] Search for todos due today — confirm "Today" label appears in muted text
- [ ] Search for todos with no due date — confirm no date label is shown
- [ ] Closed todos with past due dates should not show red (not overdue)
- [ ] Loading skeleton and empty states remain intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzZGKWB927CqkeMsPo64H

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhzZGKWB927CqkeMsPo64H)_