### PR TITLE
feat(todo-page): two-column desktop layout with sidebar properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ test-results/example-localhost-chromium/trace.zip
 *user.json
 tickup-github.2026-02-01.private-key.pem
 .gstack/
+.claude/scheduled_tasks.lock

--- a/app/components/App/BreadCrumb.vue
+++ b/app/components/App/BreadCrumb.vue
@@ -1,0 +1,172 @@
+<script setup lang="ts">
+const route = useRoute();
+const router = useRouter();
+const listsStore = useListsStore();
+const parentTodo = ref<Todo | null>(null);
+const isLoading = ref(true);
+const transitionKey = ref(0);
+
+
+async function loadTodo(id: string | string[]) {
+  try {
+    isLoading.value = true;
+
+    const todo = await $fetch<Todo>(`/api/todo/${id}`);
+    listsStore.setCurrentTodo(todo);
+
+    // Explicitly fetch subtasks for this todo
+    await listsStore.fetchSubtasks(id as string);
+
+    // If this is a subtask, ensure we have the correct parent todo
+    if (todo.parentId) {
+      const needsNewParent = !parentTodo.value || parentTodo.value.id !== todo.parentId;
+      if (needsNewParent) {
+        parentTodo.value = await $fetch<Todo>(`/api/todo/${todo.parentId}`);
+      }
+    }
+    else {
+      // No parent for this todo
+      parentTodo.value = null;
+    }
+
+    if (todo && todo.listId) {
+      const list = await $fetch<List>(`/api/list/${todo.listId}`);
+      listsStore.setCurrentList(list);
+    }
+
+    // Only bump the transition key once everything for this todo is loaded,
+    // so the fade happens between fully-rendered states.
+    transitionKey.value++;
+  }
+  finally {
+    isLoading.value = false;
+  }
+}
+
+watch(
+  () => route.params.id,
+  (id) => {
+    if (id) loadTodo(id);
+  },
+  { immediate: true },
+);
+
+const backTo = computed(() => {
+  if (parentTodo.value) return `/todo/${parentTodo.value.id}`;
+  if (listsStore.currentTodo?.listId) return `/list/${listsStore.currentTodo.listId}`;
+  return '/';
+});
+
+const backLabel = computed(() => {
+  if (parentTodo.value) return parentTodo.value.name;
+  if (listsStore.currentList?.name) return listsStore.currentList.name;
+  return 'Home';
+});
+
+const backTestId = computed(() => {
+  if (parentTodo.value) return 'nav-back-parent';
+  if (listsStore.currentTodo?.listId && listsStore.currentList?.id) return 'nav-back-list';
+  return 'nav-back-home';
+});
+</script>
+<template>
+  <div class="breadcrumb-bar">
+    <NuxtLink v-if="!isLoading" :data-testid="backTestId" @click="router.back" class="breadcrumb-back">
+      <i class="mdi mdi-arrow-left breadcrumb-back__icon" />
+    </NuxtLink>
+    <div v-if="!isLoading" class="breadcrumb-trail">
+      <NuxtLink :to="backTo" class="breadcrumb-segment breadcrumb-segment--parent">
+        {{ backLabel }}
+      </NuxtLink>
+      <i class="mdi mdi-chevron-right breadcrumb-chevron" />
+      <span class="breadcrumb-segment breadcrumb-segment--current">
+        {{ listsStore.currentTodo?.name }}
+      </span>
+    </div>
+  </div>
+</template>
+<style scoped>
+.todo-fade-enter-active {
+  transition: opacity 0.18s ease;
+}
+
+.todo-fade-enter-from {
+  opacity: 0;
+}
+
+/* Breadcrumb bar */
+.breadcrumb-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 48px;
+}
+
+.breadcrumb-back {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  color: rgba(var(--v-theme-on-surface), 0.6);
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+  flex-shrink: 0;
+}
+
+.breadcrumb-back:hover {
+  background: rgba(var(--v-border-color), 0.1);
+  color: rgb(var(--v-theme-on-surface));
+}
+
+.breadcrumb-back__icon {
+  font-size: 18px;
+}
+
+.breadcrumb-trail {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.breadcrumb-segment {
+  font-size: 0.875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.breadcrumb-segment--parent {
+  color: rgba(var(--v-theme-on-surface), 0.55);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.breadcrumb-segment--parent:hover {
+  color: rgb(var(--v-theme-primary));
+}
+
+.breadcrumb-segment--current {
+  color: rgb(var(--v-theme-on-surface));
+  font-weight: 500;
+  flex-shrink: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.breadcrumb-chevron {
+  font-size: 14px;
+  color: rgba(var(--v-theme-on-surface), 0.35);
+  flex-shrink: 0;
+}
+
+/* Page surface */
+.todo-page-surface {
+  background: #f7f9fb;
+  min-height: calc(100vh - 120px);
+  padding: 0 12px 40px;
+}
+</style>

--- a/app/components/App/DueDate.vue
+++ b/app/components/App/DueDate.vue
@@ -2,120 +2,120 @@
 import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue';
 
 const emit = defineEmits<{
-    setDate: [newDate: Date | null, newTodo: Todo];
+  setDate: [newDate: Date | null, newTodo: Todo];
 }>();
 
 const props = defineProps<{
-    todo: Todo;
-    todoDueDate?: Date | string;
-    date?: Date | string; // alias used by Todo/New.vue
-    showDetail?: boolean;
+  todo: Todo;
+  todoDueDate?: Date | string;
+  date?: Date | string; // alias used by Todo/New.vue
+  showDetail?: boolean;
 }>();
 
 // ── Date helpers (ported from prototype) ─────────────────────────────────────
 const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 const MONTHS = [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December',
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
 ];
 
 function startOfDay(d: Date): Date {
-    const x = new Date(d);
-    x.setHours(0, 0, 0, 0);
-    return x;
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
 }
 
 function addDays(d: Date, n: number): Date {
-    const x = new Date(d);
-    x.setDate(x.getDate() + n);
-    return x;
+  const x = new Date(d);
+  x.setDate(x.getDate() + n);
+  return x;
 }
 
 function sameDay(a: Date | null | undefined, b: Date | null | undefined): boolean {
-    return !!(a && b && startOfDay(a).getTime() === startOfDay(b).getTime());
+  return !!(a && b && startOfDay(a).getTime() === startOfDay(b).getTime());
 }
 
 function nextWeekday(target: number): Date {
-    // 0=Sun..6=Sat
-    const t = startOfDay(new Date());
-    for (let i = 1; i <= 7; i++) {
-        const d = addDays(t, i);
-        if (d.getDay() === target) return d;
-    }
-    return t;
+  // 0=Sun..6=Sat
+  const t = startOfDay(new Date());
+  for (let i = 1; i <= 7; i++) {
+    const d = addDays(t, i);
+    if (d.getDay() === target) return d;
+  }
+  return t;
 }
 
 function formatRelative(d: Date | null): string | null {
-    if (!d) return null;
-    const t = startOfDay(new Date());
-    const diff = Math.round((startOfDay(d).getTime() - t.getTime()) / 86400000);
-    if (diff === 0) return 'Today';
-    if (diff === 1) return 'Tomorrow';
-    if (diff === -1) return 'Yesterday';
-    if (diff > 1 && diff < 7) return d.toLocaleDateString('en-GB', { weekday: 'long' });
-    return d.toLocaleDateString('en-GB', {
-        day: 'numeric',
-        month: 'short',
-        year: d.getFullYear() !== new Date().getFullYear() ? 'numeric' : undefined,
-    });
+  if (!d) return null;
+  const t = startOfDay(new Date());
+  const diff = Math.round((startOfDay(d).getTime() - t.getTime()) / 86400000);
+  if (diff === 0) return 'Today';
+  if (diff === 1) return 'Tomorrow';
+  if (diff === -1) return 'Yesterday';
+  if (diff > 1 && diff < 7) return d.toLocaleDateString('en-GB', { weekday: 'long' });
+  return d.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: d.getFullYear() !== new Date().getFullYear() ? 'numeric' : undefined,
+  });
 }
 
 function buildMonthGrid(year: number, month: number): (Date | null)[] {
-    const first = new Date(year, month, 1);
-    const startWeekday = (first.getDay() + 6) % 7; // Mon=0
-    const daysInMonth = new Date(year, month + 1, 0).getDate();
-    const cells: (Date | null)[] = [];
-    for (let i = 0; i < startWeekday; i++) cells.push(null);
-    for (let d = 1; d <= daysInMonth; d++) cells.push(new Date(year, month, d));
-    while (cells.length % 7 !== 0) cells.push(null);
-    return cells;
+  const first = new Date(year, month, 1);
+  const startWeekday = (first.getDay() + 6) % 7; // Mon=0
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const cells: (Date | null)[] = [];
+  for (let i = 0; i < startWeekday; i++) cells.push(null);
+  for (let d = 1; d <= daysInMonth; d++) cells.push(new Date(year, month, d));
+  while (cells.length % 7 !== 0) cells.push(null);
+  return cells;
 }
 
 // ── Derived state ─────────────────────────────────────────────────────────────
 const effectiveDate = computed<Date | null>(() => {
-    const raw = props.todoDueDate ?? props.date;
-    return raw ? new Date(raw) : null;
+  const raw = props.todoDueDate ?? props.date;
+  return raw ? new Date(raw) : null;
 });
 
 const isOverdue = computed(
-    () =>
-        !!effectiveDate.value
-        && startOfDay(effectiveDate.value) < startOfDay(new Date())
-        && props.todo.status !== 'Closed',
+  () =>
+    !!effectiveDate.value
+    && startOfDay(effectiveDate.value) < startOfDay(new Date())
+    && props.todo.status !== 'Closed',
 );
 
 const isToday_ = computed(() => sameDay(effectiveDate.value, new Date()));
 
 const chipStyle = computed(() => {
-    if (!effectiveDate.value) {
-        return {
-            color: 'rgba(42,52,57,0.38)',
-            background: 'transparent',
-            borderColor: 'rgba(113,124,130,0.24)',
-        };
-    }
-    if (isOverdue.value) {
-        return { color: '#ba1b24', background: 'rgba(186,27,36,0.08)', borderColor: 'transparent' };
-    }
-    if (isToday_.value) {
-        return { color: '#005ac2', background: '#dce8ff', borderColor: 'transparent' };
-    }
-    return { color: '#2a3439', background: '#f0f4f7', borderColor: 'transparent' };
+  if (!effectiveDate.value) {
+    return {
+      color: 'rgba(42,52,57,0.38)',
+      background: 'transparent',
+      borderColor: 'rgba(113,124,130,0.24)',
+    };
+  }
+  if (isOverdue.value) {
+    return { color: '#ba1b24', background: 'rgba(186,27,36,0.08)', borderColor: 'transparent' };
+  }
+  if (isToday_.value) {
+    return { color: '#005ac2', background: '#dce8ff', borderColor: 'transparent' };
+  }
+  return { color: '#2a3439', background: '#f0f4f7', borderColor: 'transparent' };
 });
 
 const rowStyle = computed(() => ({
-    color: isOverdue.value ? '#ba1b24' : effectiveDate.value ? '#2a3439' : 'rgba(42,52,57,0.38)',
-    fontWeight: isOverdue.value ? 500 : 400,
+  color: isOverdue.value ? '#ba1b24' : effectiveDate.value ? '#2a3439' : 'rgba(42,52,57,0.38)',
+  fontWeight: isOverdue.value ? 500 : 400,
 }));
 
 // ── Popover state ─────────────────────────────────────────────────────────────
@@ -131,480 +131,424 @@ const viewMonth = ref(new Date().getMonth());
 const calendarCells = computed(() => buildMonthGrid(viewYear.value, viewMonth.value));
 
 function prevMonth() {
-    if (viewMonth.value === 0) {
-        viewMonth.value = 11;
-        viewYear.value--;
-    }
-    else viewMonth.value--;
+  if (viewMonth.value === 0) {
+    viewMonth.value = 11;
+    viewYear.value--;
+  }
+  else viewMonth.value--;
 }
 
 function nextMonth() {
-    if (viewMonth.value === 11) {
-        viewMonth.value = 0;
-        viewYear.value++;
-    }
-    else viewMonth.value++;
+  if (viewMonth.value === 11) {
+    viewMonth.value = 0;
+    viewYear.value++;
+  }
+  else viewMonth.value++;
 }
 
 // ── Quick options ─────────────────────────────────────────────────────────────
 const quicks = computed(() => {
-    const t = new Date();
-    return [
-        {
-            icon: 'mdi-white-balance-sunny',
-            label: 'Today',
-            accent: '#f07c20',
-            hint: t.toLocaleDateString('en-GB', { weekday: 'short' }),
-            date: startOfDay(t),
-        },
-        {
-            icon: 'mdi-weather-sunset-up',
-            label: 'Tomorrow',
-            accent: '#005ac2',
-            hint: addDays(t, 1).toLocaleDateString('en-GB', { weekday: 'short' }),
-            date: addDays(startOfDay(t), 1),
-        },
-        {
-            icon: 'mdi-calendar-weekend',
-            label: 'This weekend',
-            accent: '#506076',
-            hint: 'Sat',
-            date: nextWeekday(6),
-        },
-        {
-            icon: 'mdi-calendar-arrow-right',
-            label: 'Next week',
-            accent: '#506076',
-            hint: 'Mon',
-            date: nextWeekday(1),
-        },
-    ];
+  const t = new Date();
+  return [
+    {
+      icon: 'mdi-white-balance-sunny',
+      label: 'Today',
+      accent: '#f07c20',
+      hint: t.toLocaleDateString('en-GB', { weekday: 'short' }),
+      date: startOfDay(t),
+    },
+    {
+      icon: 'mdi-weather-sunset-up',
+      label: 'Tomorrow',
+      accent: '#005ac2',
+      hint: addDays(t, 1).toLocaleDateString('en-GB', { weekday: 'short' }),
+      date: addDays(startOfDay(t), 1),
+    },
+    {
+      icon: 'mdi-calendar-weekend',
+      label: 'This weekend',
+      accent: '#506076',
+      hint: 'Sat',
+      date: nextWeekday(6),
+    },
+    {
+      icon: 'mdi-calendar-arrow-right',
+      label: 'Next week',
+      accent: '#506076',
+      hint: 'Mon',
+      date: nextWeekday(1),
+    },
+  ];
 });
 
 // ── Popover open/close/position ───────────────────────────────────────────────
 async function openPicker() {
-    if (!triggerEl.value) return;
-    const d = effectiveDate.value ?? new Date();
-    viewYear.value = d.getFullYear();
-    viewMonth.value = d.getMonth();
-    open.value = true;
-    await nextTick();
-    positionPopover();
+  if (!triggerEl.value) return;
+  const d = effectiveDate.value ?? new Date();
+  viewYear.value = d.getFullYear();
+  viewMonth.value = d.getMonth();
+  open.value = true;
+  await nextTick();
+  positionPopover();
 }
 
 function positionPopover() {
-    if (!popoverEl.value || !triggerEl.value) return;
-    const a = triggerEl.value.getBoundingClientRect();
-    const r = popoverEl.value.getBoundingClientRect();
-    let left = a.left;
-    let top = a.bottom + 6;
-    if (left + r.width > window.innerWidth - 8) left = window.innerWidth - r.width - 8;
-    if (top + r.height > window.innerHeight - 8) top = a.top - r.height - 6;
-    if (top < 8) top = 8;
-    if (left < 8) left = 8;
-    popoverPos.value = { left, top, ready: true };
+  if (!popoverEl.value || !triggerEl.value) return;
+  const a = triggerEl.value.getBoundingClientRect();
+  const r = popoverEl.value.getBoundingClientRect();
+  let left = a.left;
+  let top = a.bottom + 6;
+  if (left + r.width > window.innerWidth - 8) left = window.innerWidth - r.width - 8;
+  if (top + r.height > window.innerHeight - 8) top = a.top - r.height - 6;
+  if (top < 8) top = 8;
+  if (left < 8) left = 8;
+  popoverPos.value = { left, top, ready: true };
 }
 
 function closePicker() {
-    open.value = false;
-    popoverPos.value = { left: 0, top: 0, ready: false };
+  open.value = false;
+  popoverPos.value = { left: 0, top: 0, ready: false };
 }
 
 function handleSelect(d: Date) {
-    emit('setDate', d, { ...props.todo, dueDate: d });
-    closePicker();
+  emit('setDate', d, { ...props.todo, dueDate: d });
+  closePicker();
 }
 
 function handleClear() {
-    emit('setDate', null, { ...props.todo, dueDate: undefined });
-    closePicker();
+  emit('setDate', null, { ...props.todo, dueDate: undefined });
+  closePicker();
 }
 
 function handleOutsideClick(e: MouseEvent) {
-    if (!open.value) return;
-    const t = e.target as Node;
-    if (
-        popoverEl.value
-        && !popoverEl.value.contains(t)
-        && triggerEl.value
-        && !triggerEl.value.contains(t)
-    )
-        closePicker();
+  if (!open.value) return;
+  const t = e.target as Node;
+  if (
+    popoverEl.value
+    && !popoverEl.value.contains(t)
+    && triggerEl.value
+    && !triggerEl.value.contains(t)
+  )
+    closePicker();
 }
 
 function handleEsc(e: KeyboardEvent) {
-    if (e.key === 'Escape' && open.value) closePicker();
+  if (e.key === 'Escape' && open.value) closePicker();
 }
 
 onMounted(() => {
-    document.addEventListener('mousedown', handleOutsideClick);
-    document.addEventListener('keydown', handleEsc);
+  document.addEventListener('mousedown', handleOutsideClick);
+  document.addEventListener('keydown', handleEsc);
 });
 
 onUnmounted(() => {
-    document.removeEventListener('mousedown', handleOutsideClick);
-    document.removeEventListener('keydown', handleEsc);
+  document.removeEventListener('mousedown', handleOutsideClick);
+  document.removeEventListener('keydown', handleEsc);
 });
 </script>
 
 <template>
-    <!-- Chip variant (default) -->
-    <button
-        v-if="!showDetail"
-        ref="triggerEl"
-        class="due-chip"
-        :style="chipStyle"
-        data-testid="due-date-trigger"
-        @click="openPicker"
-    >
-        <i
-            class="mdi"
-            :class="isOverdue ? 'mdi-calendar-alert' : 'mdi-calendar'"
-            style="font-size: 14px"
-        />
-        <span>{{ effectiveDate ? formatRelative(effectiveDate) : 'Set date' }}</span>
-    </button>
+  <!-- Chip variant (default) -->
+  <button v-if="!showDetail" ref="triggerEl" class="due-chip" :style="chipStyle" data-testid="due-date-trigger"
+    @click="openPicker">
+    <i class="mdi" :class="isOverdue ? 'mdi-calendar-alert' : 'mdi-calendar'" style="font-size: 14px" />
+    <span>{{ effectiveDate ? formatRelative(effectiveDate) : 'Set date' }}</span>
+  </button>
 
-    <!-- Row variant (showDetail) -->
-    <button
-        v-else
-        ref="triggerEl"
-        class="due-row"
-        :style="rowStyle"
-        data-testid="due-date-trigger"
-        @click="openPicker"
-    >
-        <i
-            v-if="isOverdue"
-            class="mdi mdi-alert-circle-outline"
-            style="font-size: 13px"
-        />
-        <span>{{ effectiveDate ? formatRelative(effectiveDate) : 'Add due date' }}</span>
-    </button>
+  <!-- Row variant (showDetail) -->
+  <button v-else ref="triggerEl" class="due-row" :style="rowStyle" data-testid="due-date-trigger" @click="openPicker">
+    <i v-if="isOverdue" class="mdi mdi-alert-circle-outline" style="font-size: 13px" />
+    <span>{{ effectiveDate ? formatRelative(effectiveDate) : 'Add due date' }}</span>
+  </button>
 
-    <!-- Popover -->
-    <Teleport to="body">
-        <div
-            v-if="open"
-            ref="popoverEl"
-            class="due-popover"
-            :style="{
-                left: popoverPos.left + 'px',
-                top: popoverPos.top + 'px',
-                opacity: popoverPos.ready ? 1 : 0,
-                transform: popoverPos.ready ? 'translateY(0)' : 'translateY(-4px)',
-            }"
-            data-testid="due-date-popover"
-        >
-            <!-- Quick options -->
-            <div class="due-quicks">
-                <button
-                    v-for="q in quicks"
-                    :key="q.label"
-                    class="due-quick"
-                    @click="handleSelect(q.date)"
-                >
-                    <i
-                        class="mdi"
-                        :class="q.icon"
-                        :style="{
-                            fontSize: '17px',
-                            width: '20px',
-                            textAlign: 'center',
-                            color: q.accent,
-                        }"
-                    />
-                    <span class="due-quick__label">{{ q.label }}</span>
-                    <span class="due-quick__hint">{{ q.hint }}</span>
-                </button>
-            </div>
+  <!-- Popover -->
+  <Teleport to="body">
+    <div v-if="open" ref="popoverEl" class="due-popover" :style="{
+      left: popoverPos.left + 'px',
+      top: popoverPos.top + 'px',
+      opacity: popoverPos.ready ? 1 : 0,
+      transform: popoverPos.ready ? 'translateY(0)' : 'translateY(-4px)',
+    }" data-testid="due-date-popover">
+      <!-- Quick options -->
+      <div class="due-quicks">
+        <button v-for="q in quicks" :key="q.label" class="due-quick" @click="handleSelect(q.date)">
+          <i class="mdi" :class="q.icon" :style="{
+            fontSize: '17px',
+            width: '20px',
+            textAlign: 'center',
+            color: q.accent,
+          }" />
+          <span class="due-quick__label">{{ q.label }}</span>
+          <span class="due-quick__hint">{{ q.hint }}</span>
+        </button>
+      </div>
 
-            <!-- Calendar -->
-            <div class="due-calendar">
-                <div class="due-cal__header">
-                    <span class="due-cal__month-label">{{ MONTHS[viewMonth] }} {{ viewYear }}</span>
-                    <div style="display: flex; gap: 2px">
-                        <button
-                            class="due-cal__nav"
-                            @click="prevMonth"
-                        >
-                            <i
-                                class="mdi mdi-chevron-left"
-                                style="font-size: 18px"
-                            />
-                        </button>
-                        <button
-                            class="due-cal__nav"
-                            @click="nextMonth"
-                        >
-                            <i
-                                class="mdi mdi-chevron-right"
-                                style="font-size: 18px"
-                            />
-                        </button>
-                    </div>
-                </div>
-
-                <div class="due-cal__weekdays">
-                    <div
-                        v-for="d in DAYS"
-                        :key="d"
-                    >
-                        {{ d }}
-                    </div>
-                </div>
-
-                <div class="due-cal__grid">
-                    <template
-                        v-for="(d, i) in calendarCells"
-                        :key="i"
-                    >
-                        <div v-if="!d" />
-                        <button
-                            v-else
-                            class="due-day"
-                            :class="{
-                                'due-day--selected': sameDay(d, effectiveDate),
-                                'due-day--today':
-                                    sameDay(d, new Date()) && !sameDay(d, effectiveDate),
-                            }"
-                            @click="handleSelect(d)"
-                        >
-                            {{ d.getDate() }}
-                        </button>
-                    </template>
-                </div>
-            </div>
-
-            <!-- Footer -->
-            <div class="due-footer">
-                <button
-                    class="due-clear"
-                    @click="handleClear"
-                >
-                    <i
-                        class="mdi mdi-close-circle-outline"
-                        style="font-size: 15px"
-                    />
-                    Clear
-                </button>
-                <span class="due-footer__preview">
-                    {{ effectiveDate ? formatRelative(effectiveDate) : 'No date set' }}
-                </span>
-            </div>
+      <!-- Calendar -->
+      <div class="due-calendar">
+        <div class="due-cal__header">
+          <span class="due-cal__month-label">{{ MONTHS[viewMonth] }} {{ viewYear }}</span>
+          <div style="display: flex; gap: 2px">
+            <button class="due-cal__nav" @click="prevMonth">
+              <i class="mdi mdi-chevron-left" style="font-size: 18px" />
+            </button>
+            <button class="due-cal__nav" @click="nextMonth">
+              <i class="mdi mdi-chevron-right" style="font-size: 18px" />
+            </button>
+          </div>
         </div>
-    </Teleport>
+
+        <div class="due-cal__weekdays">
+          <div v-for="d in DAYS" :key="d">
+            {{ d }}
+          </div>
+        </div>
+
+        <div class="due-cal__grid">
+          <template v-for="(d, i) in calendarCells" :key="i">
+            <div v-if="!d" />
+            <button v-else class="due-day" :class="{
+              'due-day--selected': sameDay(d, effectiveDate),
+              'due-day--today':
+                sameDay(d, new Date()) && !sameDay(d, effectiveDate),
+            }" @click="handleSelect(d)">
+              {{ d.getDate() }}
+            </button>
+          </template>
+        </div>
+      </div>
+
+      <!-- Footer -->
+      <div class="due-footer">
+        <button class="due-clear" @click="handleClear">
+          <i class="mdi mdi-close-circle-outline" style="font-size: 15px" />
+          Clear
+        </button>
+        <span class="due-footer__preview">
+          {{ effectiveDate ? formatRelative(effectiveDate) : 'No date set' }}
+        </span>
+      </div>
+    </div>
+  </Teleport>
 </template>
 
 <style scoped>
 /* ── Chip trigger ─────────────────────────────────────────────────────────── */
 .due-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 4px 10px;
-    border-radius: 20px;
-    border: 1px solid transparent;
-    font-size: 0.8125rem;
-    font-weight: 500;
-    font-family: Inter, sans-serif;
-    cursor: pointer;
-    transition: opacity 0.08s;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 20px;
+  border: 1px solid transparent;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  font-family: Inter, sans-serif;
+  cursor: pointer;
+  transition: opacity 0.08s;
 }
+
 .due-chip:hover {
-    opacity: 0.8;
+  opacity: 0.8;
 }
 
 /* ── Row trigger ──────────────────────────────────────────────────────────── */
 .due-row {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 4px 8px;
-    border-radius: 7px;
-    border: none;
-    background: transparent;
-    font-size: 0.875rem;
-    font-family: Inter, sans-serif;
-    cursor: pointer;
-    transition: background 0.08s;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 7px;
+  border: none;
+  background: transparent;
+  font-size: 0.875rem;
+  font-family: Inter, sans-serif;
+  cursor: pointer;
+  transition: background 0.08s;
 }
+
 .due-row:hover {
-    background: rgba(113, 124, 130, 0.1);
+  background: rgba(113, 124, 130, 0.1);
 }
 
 /* ── Popover panel ────────────────────────────────────────────────────────── */
 .due-popover {
-    position: fixed;
-    z-index: 2000;
-    width: 300px;
-    background: #ffffff;
-    border: 1px solid rgba(113, 124, 130, 0.16);
-    border-radius: 14px;
-    box-shadow:
-        0 12px 40px rgba(42, 52, 57, 0.18),
-        0 2px 8px rgba(42, 52, 57, 0.06);
-    overflow: hidden;
-    transition:
-        opacity 0.12s,
-        transform 0.12s;
+  position: fixed;
+  z-index: 2000;
+  width: 300px;
+  background: #ffffff;
+  border: 1px solid rgba(113, 124, 130, 0.16);
+  border-radius: 14px;
+  box-shadow:
+    0 12px 40px rgba(42, 52, 57, 0.18),
+    0 2px 8px rgba(42, 52, 57, 0.06);
+  overflow: hidden;
+  transition:
+    opacity 0.12s,
+    transform 0.12s;
 }
 
 /* ── Quick options ────────────────────────────────────────────────────────── */
 .due-quicks {
-    padding: 6px;
-    border-bottom: 1px solid rgba(113, 124, 130, 0.16);
+  padding: 6px;
+  border-bottom: 1px solid rgba(113, 124, 130, 0.16);
 }
 
 .due-quick {
-    display: flex;
-    align-items: center;
-    gap: 11px;
-    width: 100%;
-    padding: 8px 10px;
-    border: none;
-    border-radius: 7px;
-    cursor: pointer;
-    background: transparent;
-    color: #2a3439;
-    font-family: Inter, sans-serif;
-    font-size: 0.875rem;
-    font-weight: 500;
-    text-align: left;
-    transition: background 0.08s;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 7px;
+  cursor: pointer;
+  background: transparent;
+  color: #2a3439;
+  font-family: Inter, sans-serif;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-align: left;
+  transition: background 0.08s;
 }
+
 .due-quick:hover {
-    background: rgba(113, 124, 130, 0.1);
+  background: rgba(113, 124, 130, 0.1);
 }
+
 .due-quick__label {
-    flex: 1;
+  flex: 1;
 }
+
 .due-quick__hint {
-    font-size: 0.75rem;
-    color: rgba(42, 52, 57, 0.38);
+  font-size: 0.75rem;
+  color: rgba(42, 52, 57, 0.38);
 }
 
 /* ── Calendar ─────────────────────────────────────────────────────────────── */
 .due-calendar {
-    padding: 8px 10px;
+  padding: 8px 10px;
 }
 
 .due-cal__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 4px 6px 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 6px 10px;
 }
 
 .due-cal__month-label {
-    font-family: Manrope, sans-serif;
-    font-weight: 700;
-    font-size: 0.875rem;
-    color: #2a3439;
+  font-family: Manrope, sans-serif;
+  font-weight: 700;
+  font-size: 0.875rem;
+  color: #2a3439;
 }
 
 .due-cal__nav {
-    width: 26px;
-    height: 26px;
-    border-radius: 6px;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: rgba(42, 52, 57, 0.55);
-    transition: background 0.08s;
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(42, 52, 57, 0.55);
+  transition: background 0.08s;
 }
+
 .due-cal__nav:hover {
-    background: rgba(113, 124, 130, 0.1);
+  background: rgba(113, 124, 130, 0.1);
 }
 
 .due-cal__weekdays {
-    display: grid;
-    grid-template-columns: repeat(7, 1fr);
-    margin-bottom: 2px;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  margin-bottom: 2px;
 }
-.due-cal__weekdays > div {
-    text-align: center;
-    font-size: 0.625rem;
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: rgba(42, 52, 57, 0.38);
-    padding: 4px 0;
+
+.due-cal__weekdays>div {
+  text-align: center;
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(42, 52, 57, 0.38);
+  padding: 4px 0;
 }
 
 .due-cal__grid {
-    display: grid;
-    grid-template-columns: repeat(7, 1fr);
-    gap: 2px;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
 }
 
 /* ── Day cell ─────────────────────────────────────────────────────────────── */
 .due-day {
-    aspect-ratio: 1;
-    border: 1px solid transparent;
-    border-radius: 8px;
-    background: transparent;
-    color: #2a3439;
-    cursor: pointer;
-    font-size: 0.8125rem;
-    font-weight: 500;
-    font-family: Inter, sans-serif;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: background 0.08s;
+  aspect-ratio: 1;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: #2a3439;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  font-family: Inter, sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.08s;
 }
+
 .due-day:hover {
-    background: rgba(113, 124, 130, 0.1);
+  background: rgba(113, 124, 130, 0.1);
 }
 
 .due-day--today {
-    border-color: #005ac2;
-    color: #005ac2;
-    font-weight: 700;
+  border-color: #005ac2;
+  color: #005ac2;
+  font-weight: 700;
 }
 
 .due-day--selected {
-    background: #005ac2 !important;
-    color: #ffffff;
-    font-weight: 700;
-    border-color: transparent;
+  background: #005ac2 !important;
+  color: #ffffff;
+  font-weight: 700;
+  border-color: transparent;
 }
 
 /* ── Footer ───────────────────────────────────────────────────────────────── */
 .due-footer {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 8px 10px;
-    border-top: 1px solid rgba(113, 124, 130, 0.16);
-    background: #f7f9fb;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 10px;
+  border-top: 1px solid rgba(113, 124, 130, 0.16);
+  background: #f7f9fb;
 }
 
 .due-clear {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    padding: 5px 8px;
-    border: none;
-    background: transparent;
-    border-radius: 6px;
-    cursor: pointer;
-    color: #ba1b24;
-    font-size: 0.8125rem;
-    font-weight: 500;
-    font-family: Inter, sans-serif;
-    transition: background 0.08s;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 8px;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  color: #ba1b24;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  font-family: Inter, sans-serif;
+  transition: background 0.08s;
 }
+
 .due-clear:hover {
-    background: rgba(186, 27, 36, 0.08);
+  background: rgba(186, 27, 36, 0.08);
 }
 
 .due-footer__preview {
-    font-size: 0.75rem;
-    color: rgba(42, 52, 57, 0.38);
+  font-size: 0.75rem;
+  color: rgba(42, 52, 57, 0.38);
 }
 </style>

--- a/app/components/App/DueDate.vue
+++ b/app/components/App/DueDate.vue
@@ -89,9 +89,9 @@ const effectiveDate = computed<Date | null>(() => {
 
 const isOverdue = computed(
     () =>
-        !!effectiveDate.value &&
-        startOfDay(effectiveDate.value) < startOfDay(new Date()) &&
-        props.todo.status !== 'Closed',
+        !!effectiveDate.value
+        && startOfDay(effectiveDate.value) < startOfDay(new Date())
+        && props.todo.status !== 'Closed',
 );
 
 const isToday_ = computed(() => sameDay(effectiveDate.value, new Date()));
@@ -134,14 +134,16 @@ function prevMonth() {
     if (viewMonth.value === 0) {
         viewMonth.value = 11;
         viewYear.value--;
-    } else viewMonth.value--;
+    }
+    else viewMonth.value--;
 }
 
 function nextMonth() {
     if (viewMonth.value === 11) {
         viewMonth.value = 0;
         viewYear.value++;
-    } else viewMonth.value++;
+    }
+    else viewMonth.value++;
 }
 
 // ── Quick options ─────────────────────────────────────────────────────────────
@@ -222,10 +224,10 @@ function handleOutsideClick(e: MouseEvent) {
     if (!open.value) return;
     const t = e.target as Node;
     if (
-        popoverEl.value &&
-        !popoverEl.value.contains(t) &&
-        triggerEl.value &&
-        !triggerEl.value.contains(t)
+        popoverEl.value
+        && !popoverEl.value.contains(t)
+        && triggerEl.value
+        && !triggerEl.value.contains(t)
     )
         closePicker();
 }
@@ -272,7 +274,11 @@ onUnmounted(() => {
         data-testid="due-date-trigger"
         @click="openPicker"
     >
-        <i v-if="isOverdue" class="mdi mdi-alert-circle-outline" style="font-size: 13px" />
+        <i
+            v-if="isOverdue"
+            class="mdi mdi-alert-circle-outline"
+            style="font-size: 13px"
+        />
         <span>{{ effectiveDate ? formatRelative(effectiveDate) : 'Add due date' }}</span>
     </button>
 
@@ -318,23 +324,41 @@ onUnmounted(() => {
                 <div class="due-cal__header">
                     <span class="due-cal__month-label">{{ MONTHS[viewMonth] }} {{ viewYear }}</span>
                     <div style="display: flex; gap: 2px">
-                        <button class="due-cal__nav" @click="prevMonth">
-                            <i class="mdi mdi-chevron-left" style="font-size: 18px" />
+                        <button
+                            class="due-cal__nav"
+                            @click="prevMonth"
+                        >
+                            <i
+                                class="mdi mdi-chevron-left"
+                                style="font-size: 18px"
+                            />
                         </button>
-                        <button class="due-cal__nav" @click="nextMonth">
-                            <i class="mdi mdi-chevron-right" style="font-size: 18px" />
+                        <button
+                            class="due-cal__nav"
+                            @click="nextMonth"
+                        >
+                            <i
+                                class="mdi mdi-chevron-right"
+                                style="font-size: 18px"
+                            />
                         </button>
                     </div>
                 </div>
 
                 <div class="due-cal__weekdays">
-                    <div v-for="d in DAYS" :key="d">
+                    <div
+                        v-for="d in DAYS"
+                        :key="d"
+                    >
                         {{ d }}
                     </div>
                 </div>
 
                 <div class="due-cal__grid">
-                    <template v-for="(d, i) in calendarCells" :key="i">
+                    <template
+                        v-for="(d, i) in calendarCells"
+                        :key="i"
+                    >
                         <div v-if="!d" />
                         <button
                             v-else
@@ -354,8 +378,14 @@ onUnmounted(() => {
 
             <!-- Footer -->
             <div class="due-footer">
-                <button class="due-clear" @click="handleClear">
-                    <i class="mdi mdi-close-circle-outline" style="font-size: 15px" />
+                <button
+                    class="due-clear"
+                    @click="handleClear"
+                >
+                    <i
+                        class="mdi mdi-close-circle-outline"
+                        style="font-size: 15px"
+                    />
                     Clear
                 </button>
                 <span class="due-footer__preview">

--- a/app/components/App/Nav/Items.vue
+++ b/app/components/App/Nav/Items.vue
@@ -15,10 +15,10 @@ const menu = ref<{ listId: string; x: number; y: number } | null>(null);
 const confirmId = ref<string | null>(null);
 
 const menuList = computed(() =>
-    menu.value ? (listsStore.lists.find((l) => l.id === menu.value!.listId) ?? null) : null,
+    menu.value ? (listsStore.lists.find(l => l.id === menu.value!.listId) ?? null) : null,
 );
 const confirmList = computed(() =>
-    confirmId.value ? (listsStore.lists.find((l) => l.id === confirmId.value) ?? null) : null,
+    confirmId.value ? (listsStore.lists.find(l => l.id === confirmId.value) ?? null) : null,
 );
 
 // ── Context menu ──────────────────────────────────────────────────────────────
@@ -106,7 +106,10 @@ onUnmounted(() => {
                 dialog.open = true;
             "
         >
-            <i class="mdi mdi-plus" style="font-size: 16px" />
+            <i
+                class="mdi mdi-plus"
+                style="font-size: 16px"
+            />
         </button>
     </div>
 
@@ -141,9 +144,12 @@ onUnmounted(() => {
                 @blur="commitRename(list)"
                 @keydown.enter.prevent="commitRename(list)"
                 @keydown.esc.prevent="cancelRename"
-            />
+            >
             <!-- Name -->
-            <span v-else class="nav-row__name">{{ list.name }}</span>
+            <span
+                v-else
+                class="nav-row__name"
+            >{{ list.name }}</span>
 
             <!-- Count + dots (not during edit) -->
             <template v-if="editingId !== list.id">
@@ -159,7 +165,10 @@ onUnmounted(() => {
                         }
                     "
                 >
-                    <i class="mdi mdi-dots-horizontal" style="font-size: 16px" />
+                    <i
+                        class="mdi mdi-dots-horizontal"
+                        style="font-size: 16px"
+                    />
                 </button>
             </template>
         </div>
@@ -176,19 +185,35 @@ onUnmounted(() => {
 
     <!-- Delete confirmation -->
     <Teleport to="body">
-        <div v-if="confirmId && confirmList" class="nav-confirm-backdrop" @click="confirmId = null">
-            <div class="nav-confirm-dialog" @click.stop>
+        <div
+            v-if="confirmId && confirmList"
+            class="nav-confirm-backdrop"
+            @click="confirmId = null"
+        >
+            <div
+                class="nav-confirm-dialog"
+                @click.stop
+            >
                 <div class="nav-confirm-icon">
-                    <i class="mdi mdi-trash-can-outline" style="font-size: 22px; color: #ba1b24" />
+                    <i
+                        class="mdi mdi-trash-can-outline"
+                        style="font-size: 22px; color: #ba1b24"
+                    />
                 </div>
-                <div class="nav-confirm-title">Delete list</div>
+                <div class="nav-confirm-title">
+                    Delete list
+                </div>
                 <div class="nav-confirm-body">
                     Are you sure you want to delete
-                    <strong>{{ confirmList.name }}</strong
-                    >? All tasks in this list will be permanently removed.
+                    <strong>{{ confirmList.name }}</strong>? All tasks in this list will be permanently removed.
                 </div>
                 <div class="nav-confirm-actions">
-                    <button class="nav-confirm-cancel" @click="confirmId = null">Cancel</button>
+                    <button
+                        class="nav-confirm-cancel"
+                        @click="confirmId = null"
+                    >
+                        Cancel
+                    </button>
                     <button
                         class="nav-confirm-delete"
                         data-testid="delete-list"

--- a/app/components/App/Nav/Mobile.vue
+++ b/app/components/App/Nav/Mobile.vue
@@ -5,8 +5,8 @@ const isKeyboardOpen = ref(false);
 
 if (import.meta.client) {
     const onViewportResize = () => {
-        isKeyboardOpen.value =
-            (window.visualViewport?.height ?? window.innerHeight) < window.innerHeight * 0.75;
+        isKeyboardOpen.value
+            = (window.visualViewport?.height ?? window.innerHeight) < window.innerHeight * 0.75;
     };
     window.visualViewport?.addEventListener('resize', onViewportResize);
     onUnmounted(() => window.visualViewport?.removeEventListener('resize', onViewportResize));
@@ -46,7 +46,10 @@ function isActive(to: string) {
 </script>
 
 <template>
-    <nav v-if="!isKeyboardOpen" class="mobile-nav">
+    <nav
+        v-if="!isKeyboardOpen"
+        class="mobile-nav"
+    >
         <button
             v-for="item in leftItems"
             :key="item.key"
@@ -70,7 +73,10 @@ function isActive(to: string) {
                     dialog.open = true;
                 "
             >
-                <i class="mdi mdi-plus" style="font-size: 26px" />
+                <i
+                    class="mdi mdi-plus"
+                    style="font-size: 26px"
+                />
             </button>
         </div>
 

--- a/app/components/App/Nav/index.vue
+++ b/app/components/App/Nav/index.vue
@@ -44,8 +44,15 @@ async function signOut() {
     >
         <Search ref="searchRef" />
 
-        <v-list nav class="flex-shrink-0">
-            <v-list-item prepend-icon="mdi-view-dashboard-outline" title="My Work" to="/" />
+        <v-list
+            nav
+            class="flex-shrink-0"
+        >
+            <v-list-item
+                prepend-icon="mdi-view-dashboard-outline"
+                title="My Work"
+                to="/"
+            />
             <v-list-item
                 prepend-icon="mdi-magnify"
                 title="Search"
@@ -54,16 +61,28 @@ async function signOut() {
             <v-divider class="mt-1 mb-0" />
         </v-list>
 
-        <v-list nav class="overflow-y-auto flex-grow-1">
-            <ListNew :open="dialog" @close="dialog.open = false" />
+        <v-list
+            nav
+            class="overflow-y-auto flex-grow-1"
+        >
+            <ListNew
+                :open="dialog"
+                @close="dialog.open = false"
+            />
             <AppNavItems />
         </v-list>
 
         <template #append>
             <!-- Account footer -->
-            <div ref="footerEl" class="nav-account-footer">
+            <div
+                ref="footerEl"
+                class="nav-account-footer"
+            >
                 <!-- Popover — opens upward -->
-                <div v-if="acctOpen" class="nav-account-popover">
+                <div
+                    v-if="acctOpen"
+                    class="nav-account-popover"
+                >
                     <button
                         class="nav-account-popover-item"
                         @click="
@@ -74,7 +93,10 @@ async function signOut() {
                         <i class="mdi mdi-cog-outline nav-account-popover-item__icon" />
                         Settings
                     </button>
-                    <button class="nav-account-popover-item" @click="signOut">
+                    <button
+                        class="nav-account-popover-item"
+                        @click="signOut"
+                    >
                         <i class="mdi mdi-logout nav-account-popover-item__icon" />
                         Sign out
                     </button>
@@ -87,7 +109,10 @@ async function signOut() {
                     @click="toggleAcct"
                 >
                     <div class="nav-account-avatar">
-                        <i class="mdi mdi-account" style="font-size: 16px" />
+                        <i
+                            class="mdi mdi-account"
+                            style="font-size: 16px"
+                        />
                     </div>
                     <span class="nav-account-email">{{ user?.email }}</span>
                     <i

--- a/app/components/Board/Column.vue
+++ b/app/components/Board/Column.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 const isAddingTodo = ref(false);
 const listsStore = useListsStore();
-const statusStore = useSettingsStore();
 
 interface Props {
     status: Status;
@@ -112,9 +111,7 @@ function handleDragChange(evt: any) {
                                     class="flex-shrink-0"
                                     @click.stop
                                 />
-                                <span
-                                    class="text-truncate text-body-1 font-weight-bold flex-grow-1 mr-2"
-                                >{{ todo.name }}</span>
+                                <span class="text-truncate text-body-1 font-weight-bold flex-grow-1 mr-2">{{ todo.name }}</span>
                             </div>
                         </v-card-item>
                     </v-card>
@@ -142,37 +139,37 @@ function handleDragChange(evt: any) {
 
 <style scoped>
 .ghost {
-    opacity: 0.5;
-    background-color: inherit;
+  opacity: 0.5;
+  background-color: inherit;
 }
 
 :deep(.v-card-title) {
-    font-weight: bold !important;
+  font-weight: bold !important;
 }
 
 .list :deep(.v-card-item__content:first-child) {
-    height: 100% !important;
+  height: 100% !important;
 
-    .draggable-container {
-        min-height: 100%;
-        overflow-y: auto;
-    }
+  .draggable-container {
+    min-height: 100%;
+    overflow-y: auto;
+  }
 }
 
 /* Mobile-specific styles */
 @media (max-width: 768px) {
-    :deep(.v-card) {
-        min-width: 0 !important;
-        width: 100% !important;
-    }
+  :deep(.v-card) {
+    min-width: 0 !important;
+    width: 100% !important;
+  }
 
-    :deep(.v-card-item) {
-        padding: 8px 12px !important;
-    }
+  :deep(.v-card-item) {
+    padding: 8px 12px !important;
+  }
 
-    :deep(.text-truncate) {
-        word-wrap: break-word;
-        overflow-wrap: break-word;
-    }
+  :deep(.text-truncate) {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+  }
 }
 </style>

--- a/app/components/List/Simple.vue
+++ b/app/components/List/Simple.vue
@@ -1,348 +1,298 @@
 <script setup lang="ts">
 const listsStore = useListsStore();
+const { mobile } = useDisplay()
 
 const openGroupExpanded = ref(true);
 const closedGroupExpanded = ref(false);
 
 function selectTodo(todo: Todo) {
-    listsStore.setCurrentTodo(todo);
+  listsStore.setCurrentTodo(todo);
+  if (mobile.value) {
+    navigateTo(`/todo/${todo.id}`)
+  } else {
     listsStore.panelOpen = true;
+  }
 }
 
 function setClosed(todo: Todo) {
-    todo.status = 'Closed';
-    listsStore.updateTodo(todo);
+  todo.status = 'Closed';
+  listsStore.updateTodo(todo);
 }
 
 function setOpen(todo: Todo) {
-    todo.status = 'Open';
-    listsStore.updateTodo(todo);
+  todo.status = 'Open';
+  listsStore.updateTodo(todo);
 }
 
 function formatDate(date: Date) {
-    if (!date) return '';
-    return new Date(date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+  if (!date) return '';
+  return new Date(date).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
 }
 
 const today = new Date();
 today.setHours(0, 0, 0, 0);
 
 function isOverdue(todo: Todo) {
-    if (!todo.dueDate || todo.status === 'Closed') return false;
-    const d = new Date(todo.dueDate);
-    d.setHours(0, 0, 0, 0);
-    return d < today;
+  if (!todo.dueDate || todo.status === 'Closed') return false;
+  const d = new Date(todo.dueDate);
+  d.setHours(0, 0, 0, 0);
+  return d < today;
 }
 
 const openTodos = computed(
-    () => listsStore.currentList.todos?.filter((t: Todo) => t.status !== 'Closed') ?? [],
+  () => listsStore.currentList.todos?.filter((t: Todo) => t.status !== 'Closed') ?? [],
 );
 
 const closedTodos = computed(
-    () => listsStore.currentList.todos?.filter((t: Todo) => t.status === 'Closed') ?? [],
+  () => listsStore.currentList.todos?.filter((t: Todo) => t.status === 'Closed') ?? [],
 );
 </script>
 
 <template>
-    <div class="list-view">
-        <div
-            v-if="listsStore.currentList.todos?.length"
-            class="simple-list"
-        >
-            <!-- Open group -->
-            <div class="group">
-                <button
-                    class="group__header"
-                    @click="openGroupExpanded = !openGroupExpanded"
-                >
-                    <i
-                        :class="`mdi ${openGroupExpanded ? 'mdi-chevron-down' : 'mdi-chevron-right'} group__chevron`"
-                    />
-                    <span class="group__title">Open</span>
-                    <span class="group__count">{{ openTodos.length }}</span>
-                </button>
+  <div class="list-view">
+    <div v-if="listsStore.currentList.todos?.length" class="simple-list">
+      <!-- Open group -->
+      <div class="group">
+        <button class="group__header" @click="openGroupExpanded = !openGroupExpanded">
+          <i :class="`mdi ${openGroupExpanded ? 'mdi-chevron-down' : 'mdi-chevron-right'} group__chevron`" />
+          <span class="group__title">Open</span>
+          <span class="group__count">{{ openTodos.length }}</span>
+        </button>
 
-                <ul
-                    v-if="openGroupExpanded"
-                    class="todo-list"
-                >
-                    <li
-                        v-for="todo in openTodos"
-                        :key="todo.id"
-                        class="todo-item"
-                        :class="{
-                            'todo-item--selected':
-                                listsStore.currentTodo?.id === todo.id && listsStore.panelOpen,
-                        }"
-                        @click="selectTodo(todo)"
-                    >
-                        <button
-                            class="todo-checkbox"
-                            :aria-label="`Close ${todo.name}`"
-                            @click.stop="setClosed(todo)"
-                        />
+        <ul v-if="openGroupExpanded" class="todo-list">
+          <li v-for="todo in openTodos" :key="todo.id" class="todo-item" :class="{
+            'todo-item--selected':
+              listsStore.currentTodo?.id === todo.id && listsStore.panelOpen,
+          }" @click="selectTodo(todo)">
+            <button class="todo-checkbox" :aria-label="`Close ${todo.name}`" @click.stop="setClosed(todo)" />
 
-                        <div class="todo-item__content">
-                            <span
-                                class="todo-title"
-                                data-testid="todo-title"
-                            >{{ todo.name }}</span>
-                            <span
-                                v-if="todo.dueDate"
-                                class="todo-subtitle"
-                                :class="{ 'todo-subtitle--overdue': isOverdue(todo) }"
-                            >
-                                <i
-                                    v-if="isOverdue(todo)"
-                                    class="mdi mdi-alert-circle-outline"
-                                    style="font-size: 11px"
-                                />
-                                {{ formatDate(todo.dueDate) }}
-                            </span>
-                        </div>
-
-                        <i class="mdi mdi-chevron-right todo-item__arrow" />
-                    </li>
-                </ul>
+            <div class="todo-item__content">
+              <span class="todo-title" data-testid="todo-title">{{ todo.name }}</span>
+              <span v-if="todo.dueDate" class="todo-subtitle" :class="{ 'todo-subtitle--overdue': isOverdue(todo) }">
+                <i v-if="isOverdue(todo)" class="mdi mdi-alert-circle-outline" style="font-size: 11px" />
+                {{ formatDate(todo.dueDate) }}
+              </span>
             </div>
 
-            <!-- Closed group -->
-            <div class="group">
-                <button
-                    class="group__header"
-                    @click="closedGroupExpanded = !closedGroupExpanded"
-                >
-                    <i
-                        :class="`mdi ${closedGroupExpanded ? 'mdi-chevron-down' : 'mdi-chevron-right'} group__chevron`"
-                    />
-                    <span class="group__title">Closed</span>
-                    <span class="group__count">{{ closedTodos.length }}</span>
-                </button>
+            <i class="mdi mdi-chevron-right todo-item__arrow" />
+          </li>
+        </ul>
+      </div>
 
-                <ul
-                    v-if="closedGroupExpanded"
-                    class="todo-list"
-                >
-                    <li
-                        v-for="todo in closedTodos"
-                        :key="todo.id"
-                        class="todo-item todo-item--closed"
-                        :class="{
-                            'todo-item--selected':
-                                listsStore.currentTodo?.id === todo.id && listsStore.panelOpen,
-                        }"
-                        @click="selectTodo(todo)"
-                    >
-                        <button
-                            class="todo-checkbox todo-checkbox--checked"
-                            :aria-label="`Reopen ${todo.name}`"
-                            @click.stop="setOpen(todo)"
-                        >
-                            <i class="mdi mdi-check todo-checkbox__indicator" />
-                        </button>
+      <!-- Closed group -->
+      <div class="group">
+        <button class="group__header" @click="closedGroupExpanded = !closedGroupExpanded">
+          <i :class="`mdi ${closedGroupExpanded ? 'mdi-chevron-down' : 'mdi-chevron-right'} group__chevron`" />
+          <span class="group__title">Closed</span>
+          <span class="group__count">{{ closedTodos.length }}</span>
+        </button>
 
-                        <div class="todo-item__content">
-                            <span class="todo-title todo-title--closed">{{ todo.name }}</span>
-                            <span
-                                v-if="todo.dueDate"
-                                class="todo-subtitle"
-                            >{{
-                                formatDate(todo.dueDate)
-                            }}</span>
-                        </div>
+        <ul v-if="closedGroupExpanded" class="todo-list">
+          <li v-for="todo in closedTodos" :key="todo.id" class="todo-item todo-item--closed" :class="{
+            'todo-item--selected':
+              listsStore.currentTodo?.id === todo.id && listsStore.panelOpen,
+          }" @click="selectTodo(todo)">
+            <button class="todo-checkbox todo-checkbox--checked" :aria-label="`Reopen ${todo.name}`"
+              @click.stop="setOpen(todo)">
+              <i class="mdi mdi-check todo-checkbox__indicator" />
+            </button>
 
-                        <i class="mdi mdi-chevron-right todo-item__arrow" />
-                    </li>
-                </ul>
+            <div class="todo-item__content">
+              <span class="todo-title todo-title--closed">{{ todo.name }}</span>
+              <span v-if="todo.dueDate" class="todo-subtitle">{{
+                formatDate(todo.dueDate)
+              }}</span>
             </div>
-        </div>
 
-        <div
-            v-else
-            class="empty-wrapper"
-        >
-            <AppEmptyState />
-        </div>
+            <i class="mdi mdi-chevron-right todo-item__arrow" />
+          </li>
+        </ul>
+      </div>
     </div>
+
+    <div v-else class="empty-wrapper">
+      <AppEmptyState />
+    </div>
+  </div>
 </template>
 
 <style scoped>
 .list-view {
-    height: 100%;
-    overflow-y: auto;
-    padding: 4px 0 40px;
+  height: 100%;
+  overflow-y: auto;
+  padding: 4px 0 40px;
 }
 
 .simple-list {
-    padding: 0;
+  padding: 0;
 }
 
 /* Group */
 .group {
-    margin-bottom: 4px;
+  margin-bottom: 4px;
 }
 
 .group__header {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    width: 100%;
-    padding: 6px 12px;
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    text-align: left;
-    border-radius: 8px;
-    font-family: inherit;
-    transition: background 0.1s;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 12px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  border-radius: 8px;
+  font-family: inherit;
+  transition: background 0.1s;
 }
 
 .group__header:hover {
-    background: rgba(var(--v-border-color), 0.06);
+  background: rgba(var(--v-border-color), 0.06);
 }
 
 .group__chevron {
-    font-size: 16px;
-    color: rgba(var(--v-theme-on-surface), 0.4);
+  font-size: 16px;
+  color: rgba(var(--v-theme-on-surface), 0.4);
 }
 
 .group__title {
-    font-weight: 600;
-    font-size: 0.8125rem;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    color: rgba(var(--v-theme-on-surface), 0.5);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(var(--v-theme-on-surface), 0.5);
 }
 
 .group__count {
-    font-size: 0.8125rem;
-    font-weight: 600;
-    color: rgba(var(--v-theme-on-surface), 0.35);
-    margin-left: 2px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: rgba(var(--v-theme-on-surface), 0.35);
+  margin-left: 2px;
 }
 
 /* Todo list */
 .todo-list {
-    list-style: none;
-    margin: 0;
-    padding: 0 4px;
+  list-style: none;
+  margin: 0;
+  padding: 0 4px;
 }
 
 .todo-item {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 7px 10px;
-    border-radius: 8px;
-    cursor: pointer;
-    margin-bottom: 1px;
-    border-left: 3px solid transparent;
-    transition: background 0.1s;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  margin-bottom: 1px;
+  border-left: 3px solid transparent;
+  transition: background 0.1s;
 }
 
 .todo-item:hover {
-    background: rgba(var(--v-border-color), 0.07);
+  background: rgba(var(--v-border-color), 0.07);
 }
 
 .todo-item--selected {
-    background: rgb(var(--v-theme-primary-container));
-    border-left-color: rgb(var(--v-theme-primary));
+  background: rgb(var(--v-theme-primary-container));
+  border-left-color: rgb(var(--v-theme-primary));
 }
 
 .todo-item--selected:hover {
-    background: rgb(var(--v-theme-primary-container));
+  background: rgb(var(--v-theme-primary-container));
 }
 
 .todo-item--closed {
-    opacity: 0.6;
+  opacity: 0.6;
 }
 
 .todo-item__arrow {
-    font-size: 15px;
-    color: rgba(var(--v-theme-on-surface), 0.25);
-    opacity: 0;
-    transition: opacity 0.1s;
-    flex-shrink: 0;
+  font-size: 15px;
+  color: rgba(var(--v-theme-on-surface), 0.25);
+  opacity: 0;
+  transition: opacity 0.1s;
+  flex-shrink: 0;
 }
 
 .todo-item:hover .todo-item__arrow,
 .todo-item--selected .todo-item__arrow {
-    opacity: 1;
+  opacity: 1;
 }
 
 /* Checkbox */
 .todo-checkbox {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 17px;
-    height: 17px;
-    border: 2px solid rgba(var(--v-border-color), 0.38);
-    border-radius: 4px;
-    cursor: pointer;
-    background: transparent;
-    flex-shrink: 0;
-    transition:
-        border-color 0.15s,
-        background 0.15s;
-    padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 17px;
+  height: 17px;
+  border: 2px solid rgba(var(--v-border-color), 0.38);
+  border-radius: 4px;
+  cursor: pointer;
+  background: transparent;
+  flex-shrink: 0;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+  padding: 0;
 }
 
 .todo-checkbox:hover {
-    border-color: rgb(var(--v-theme-primary));
+  border-color: rgb(var(--v-theme-primary));
 }
 
 .todo-checkbox--checked {
-    background: rgb(var(--v-theme-primary));
-    border-color: rgb(var(--v-theme-primary));
+  background: rgb(var(--v-theme-primary));
+  border-color: rgb(var(--v-theme-primary));
 }
 
 .todo-checkbox__indicator {
-    color: rgb(var(--v-theme-on-primary));
-    font-size: 10px;
+  color: rgb(var(--v-theme-on-primary));
+  font-size: 10px;
 }
 
 /* Todo content */
 .todo-item__content {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 1px;
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
 }
 
 .todo-title {
-    font-weight: 500;
-    font-size: 0.9375rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: rgb(var(--v-theme-on-surface));
+  font-weight: 500;
+  font-size: 0.9375rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: rgb(var(--v-theme-on-surface));
 }
 
 .todo-title--closed {
-    text-decoration: line-through;
+  text-decoration: line-through;
 }
 
 .todo-subtitle {
-    font-size: 0.75rem;
-    color: rgba(var(--v-theme-on-surface), 0.45);
-    display: flex;
-    align-items: center;
-    gap: 3px;
+  font-size: 0.75rem;
+  color: rgba(var(--v-theme-on-surface), 0.45);
+  display: flex;
+  align-items: center;
+  gap: 3px;
 }
 
 .todo-subtitle--overdue {
-    color: rgb(var(--v-theme-tertiary));
-    font-weight: 500;
+  color: rgb(var(--v-theme-tertiary));
+  font-weight: 500;
 }
 
 /* Empty state */
 .empty-wrapper {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 100%;
-    padding: 48px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 48px 24px;
 }
 </style>

--- a/app/components/List/Type.vue
+++ b/app/components/List/Type.vue
@@ -2,51 +2,46 @@
 const listTypeOptions = ref<ListType[]>(['table', 'simple']);
 const props = defineProps<{ currentListType?: ListType }>();
 const selectedType = ref<ListType>(
-    props.currentListType && props.currentListType !== '' ? props.currentListType : 'simple',
+  props.currentListType ? props.currentListType : 'simple',
 );
 const emit = defineEmits<{
-    listTypeUpdated: [listType: ListType];
+  listTypeUpdated: [listType: ListType];
 }>();
+
+const listsStore = useListsStore()
 
 // Watch for prop changes to update selectedType
 watch(
-    () => props.currentListType,
-    (newVal) => {
-        const validValue = newVal && newVal !== '' ? newVal : 'simple';
-        if (validValue !== selectedType.value) {
-            selectedType.value = validValue;
-        }
-    },
-    { immediate: true },
+  () => props.currentListType,
+  (newVal) => {
+    if (newVal !== selectedType.value) {
+      selectedType.value = newVal;
+      if (newVal === 'table' && !listsStore.panelOpen) {
+        listsStore.panelOpen = false;
+      }
+    }
+  },
+  { immediate: true },
 );
 
 // Watch for selectedType changes to emit updates
 watch(selectedType, (newVal: ListType, oldVal: ListType) => {
-    if (newVal !== oldVal) {
-        emit('listTypeUpdated', newVal);
-    }
+  if (newVal !== oldVal) {
+    emit('listTypeUpdated', newVal);
+  }
 });
 </script>
 
 <template>
-    <v-select
-        v-model="selectedType"
-        :items="listTypeOptions"
-        single-line
-        min-width="60"
-        max-width="150"
-        variant="outlined"
-        flat
-        elevation="0"
-        data-testid="list-type-select"
-    />
+  <v-select v-model="selectedType" :items="listTypeOptions" single-line min-width="60" max-width="150"
+    variant="outlined" flat elevation="0" data-testid="list-type-select" />
 </template>
 
 <style scoped>
 :deep(.v-field__input) {
-    padding: 0.75em;
-    min-height: 0;
-    height: 100%;
-    /* max-height: 48px; */
+  padding: 0.75em;
+  min-height: 0;
+  height: 100%;
+  /* max-height: 48px; */
 }
 </style>

--- a/app/components/Search/index.vue
+++ b/app/components/Search/index.vue
@@ -65,7 +65,10 @@ onMounted(() => {
         @after-leave="open = false"
     >
         <template #default="{ isActive }">
-            <v-card v-show="isActive" min-height="300">
+            <v-card
+                v-show="isActive"
+                min-height="300"
+            >
                 <v-card-item class="pa-4">
                     <v-text-field
                         v-model="searchStore.searchQuery"
@@ -79,7 +82,10 @@ onMounted(() => {
 
                 <v-card-item>
                     <v-list v-if="loading">
-                        <v-list-item v-for="n in 5" :key="n">
+                        <v-list-item
+                            v-for="n in 5"
+                            :key="n"
+                        >
                             <v-skeleton-loader type="list-item" />
                         </v-list-item>
                     </v-list>

--- a/app/components/Settings/Column.vue
+++ b/app/components/Settings/Column.vue
@@ -1,80 +1,60 @@
 <script setup lang="ts">
 interface Props {
-    title: string;
-    icon?: string;
-    description?: string;
-    /**
-     * Optional status label shown as a chip in the header, e.g. "Connected" / "Not connected".
-     */
-    statusLabel?: string;
-    /**
-     * Status chip color, e.g. "success", "error", "warning" or any Vuetify color.
-     */
-    statusColor?: string;
-    /**
-     * Optional data-testid for Playwright and other tests.
-     */
-    testId?: string;
+  title: string;
+  icon?: string;
+  description?: string;
+  /**
+   * Optional status label shown as a chip in the header, e.g. "Connected" / "Not connected".
+   */
+  statusLabel?: string;
+  /**
+   * Status chip color, e.g. "success", "error", "warning" or any Vuetify color.
+   */
+  statusColor?: string;
+  /**
+   * Optional data-testid for Playwright and other tests.
+   */
+  testId?: string;
 }
 
 const props = defineProps<Props>();
 </script>
 
 <template>
-    <v-col
-        cols="12"
-        md="6"
-        lg="4"
-        class="settings-column"
-        :data-testid="props.testId"
-    >
-        <v-card
-            class="pa-4 d-flex flex-column h-100"
-            variant="flat"
-        >
-            <v-card-title class="d-flex align-center justify-space-between px-0 pt-0 pb-2">
-                <div class="d-flex align-center ga-2">
-                    <v-icon
-                        v-if="props.icon"
-                        :icon="props.icon"
-                    />
-                    <span class="font-weight-medium text-subtitle-1">
-                        {{ props.title }}
-                    </span>
-                </div>
-                <v-chip
-                    v-if="props.statusLabel"
-                    size="small"
-                    :color="props.statusColor || 'default'"
-                    variant="tonal"
-                >
-                    {{ props.statusLabel }}
-                </v-chip>
-            </v-card-title>
+  <v-col cols="12" md="6" lg="4" class="settings-column" :data-testid="props.testId">
+    <v-card class="pa-4 d-flex flex-column h-100" variant="flat">
+      <v-card-title class="d-flex align-center justify-space-between px-0 pt-0 pb-2">
+        <div class="d-flex align-center ga-2">
+          <v-icon v-if="props.icon" :icon="props.icon" />
+          <span class="font-weight-medium text-subtitle-1">
+            {{ props.title }}
+          </span>
+        </div>
+        <v-chip v-if="props.statusLabel" size="small" :color="props.statusColor || 'default'" variant="tonal">
+          {{ props.statusLabel }}
+        </v-chip>
+      </v-card-title>
 
-            <v-card-subtitle
-                v-if="props.description"
-                class="px-0 pb-3 text-body-2"
-            >
-                {{ props.description }}
-            </v-card-subtitle>
+      <v-card-subtitle v-if="props.description" class="px-0 pb-3 text-body-2">
+        {{ props.description }}
+      </v-card-subtitle>
 
-            <v-card-text class="px-0 pt-0 pb-3 flex-grow-1">
-                <!-- Main content for the column (form fields, selectors, etc.) -->
-                <slot />
-            </v-card-text>
+      <v-card-text class="px-0 pt-0 pb-3 flex-grow-1">
+        <!-- Main content for the column (form fields, selectors, etc.) -->
+        <slot />
+      </v-card-text>
 
-            <v-card-actions class="px-0 pt-0">
-                <!-- Optional footer actions (buttons, links, etc.) -->
-                <slot name="actions" />
-            </v-card-actions>
-        </v-card>
-    </v-col>
+      <v-card-actions class="px-0 pt-0">
+        <!-- Optional footer actions (buttons, links, etc.) -->
+        <slot name="actions" />
+      </v-card-actions>
+    </v-card>
+  </v-col>
 </template>
 
 <style scoped>
 .settings-column {
-    /* Ensure consistent vertical spacing between columns */
-    margin-bottom: 16px;
+  /* Ensure consistent vertical spacing between columns */
+  margin-bottom: 16px;
 }
 </style>

--- a/app/components/Subtask/index.vue
+++ b/app/components/Subtask/index.vue
@@ -15,12 +15,12 @@ const editingSubtaskIds = ref<(string | number)[]>([]);
 const isEditingSubtask = (id: string | number) => editingSubtaskIds.value.includes(id);
 
 const getPriorityOrder = (priority: string | null | undefined): number => {
-    if (!priority) return 4;
-    const p = priority.toLowerCase();
-    if (p === 'high') return 1;
-    if (p === 'medium') return 2;
-    if (p === 'low') return 3;
-    return 4;
+  if (!priority) return 4;
+  const p = priority.toLowerCase();
+  if (p === 'high') return 1;
+  if (p === 'medium') return 2;
+  if (p === 'low') return 3;
+  return 4;
 };
 
 const allSubtasks = computed(() => listsStore.currentTodo?.subtasks || []);
@@ -28,757 +28,599 @@ const total = computed(() => allSubtasks.value.length);
 const doneCount = computed(() => allSubtasks.value.filter(s => s.status === 'Closed').length);
 
 function sortBy(list: Todo[]): Todo[] {
-    if (subtasksSortBy.value !== 'priority') return list;
-    return [...list].sort(
-        (a, b) => getPriorityOrder(a.priorityLev) - getPriorityOrder(b.priorityLev),
-    );
+  if (subtasksSortBy.value !== 'priority') return list;
+  return [...list].sort(
+    (a, b) => getPriorityOrder(a.priorityLev) - getPriorityOrder(b.priorityLev),
+  );
 }
 
 const activeSubtasks = computed(() =>
-    sortBy(allSubtasks.value.filter(s => s.status !== 'Closed')),
+  sortBy(allSubtasks.value.filter(s => s.status !== 'Closed')),
 );
 const closedSubtasks = computed(() =>
-    sortBy(allSubtasks.value.filter(s => s.status === 'Closed')),
+  sortBy(allSubtasks.value.filter(s => s.status === 'Closed')),
 );
 
 const baseLinkableTodos = computed(() => {
-    const todos = listsStore.currentList?.todos || [];
-    return todos.filter((todo) => {
-        if (!todo.id || listsStore.currentTodo?.id === todo.id) return false;
-        if ((todo as any).parentId) return false;
-        if (listsStore.currentTodo?.subtasks?.some(st => st.id === todo.id)) return false;
-        return true;
-    });
+  const todos = listsStore.currentList?.todos || [];
+  return todos.filter((todo) => {
+    if (!todo.id || listsStore.currentTodo?.id === todo.id) return false;
+    if ((todo as any).parentId) return false;
+    if (listsStore.currentTodo?.subtasks?.some(st => st.id === todo.id)) return false;
+    return true;
+  });
 });
 
 const linkableTodos = computed(() => {
-    let todos = [...baseLinkableTodos.value];
-    const q = String(linkSearch.value ?? '')
-        .trim()
-        .toLowerCase();
-    if (q) todos = todos.filter(todo => todo.name?.toLowerCase().includes(q));
+  let todos = [...baseLinkableTodos.value];
+  const q = String(linkSearch.value ?? '')
+    .trim()
+    .toLowerCase();
+  if (q) todos = todos.filter(todo => todo.name?.toLowerCase().includes(q));
 
-    todos.sort((a, b) => {
-        const getTime = (t: any) => {
-            if (t.updatedAt) return new Date(t.updatedAt).getTime();
-            if (t.dueDate) return new Date(t.dueDate).getTime();
-            if (t.id) {
-                const n = Number(t.id);
-                return Number.isNaN(n) ? 0 : n;
-            }
-            return 0;
-        };
-        return getTime(b) - getTime(a);
-    });
-    return todos;
+  todos.sort((a, b) => {
+    const getTime = (t: any) => {
+      if (t.updatedAt) return new Date(t.updatedAt).getTime();
+      if (t.dueDate) return new Date(t.dueDate).getTime();
+      if (t.id) {
+        const n = Number(t.id);
+        return Number.isNaN(n) ? 0 : n;
+      }
+      return 0;
+    };
+    return getTime(b) - getTime(a);
+  });
+  return todos;
 });
 
 async function addSubtask() {
-    if (!newSubtaskName.value || !listsStore.currentTodo?.id) return;
-    await listsStore.addSubtask(newSubtaskName.value, listsStore.currentTodo.id);
-    newSubtaskName.value = '';
+  if (!newSubtaskName.value || !listsStore.currentTodo?.id) return;
+  await listsStore.addSubtask(newSubtaskName.value, listsStore.currentTodo.id);
+  newSubtaskName.value = '';
 }
 
 async function deleteSubtask(subtaskId: string | number) {
-    await listsStore.deleteSubtask(subtaskId);
+  await listsStore.deleteSubtask(subtaskId);
 }
 
 async function linkExistingTodo(todo: Todo) {
-    if (!listsStore.currentTodo?.id || !todo.id) return;
-    if ((todo as any).parentId) return;
-    todo.parentId = listsStore.currentTodo.id;
-    const updated = await listsStore.updateTodo(todo);
-    if (!listsStore.currentTodo.subtasks) listsStore.currentTodo.subtasks = [];
-    if (!listsStore.currentTodo.subtasks.some(st => st.id === updated.id)) {
-        listsStore.currentTodo.subtasks.push(updated);
-    }
+  if (!listsStore.currentTodo?.id || !todo.id) return;
+  if ((todo as any).parentId) return;
+  todo.parentId = listsStore.currentTodo.id;
+  const updated = await listsStore.updateTodo(todo);
+  if (!listsStore.currentTodo.subtasks) listsStore.currentTodo.subtasks = [];
+  if (!listsStore.currentTodo.subtasks.some(st => st.id === updated.id)) {
+    listsStore.currentTodo.subtasks.push(updated);
+  }
 }
 
 function navigateToSubtask(subtaskId: string | number) {
-    router.push(`/todo/${subtaskId}`);
+  router.push(`/todo/${subtaskId}`);
 }
 
 function renameSubtask(subtaskId: string | number, index: number) {
-    if (!editingSubtaskIds.value.includes(subtaskId)) {
-        editingSubtaskIds.value.push(subtaskId);
-    }
-    const input = subtaskNameRefs.value[index];
-    if (input && typeof input.focus === 'function') {
-        nextTick(() => input.focus());
-    }
+  if (!editingSubtaskIds.value.includes(subtaskId)) {
+    editingSubtaskIds.value.push(subtaskId);
+  }
+  const input = subtaskNameRefs.value[index];
+  if (input && typeof input.focus === 'function') {
+    nextTick(() => input.focus());
+  }
 }
 
 function onSubtaskBlur(subtask: Todo) {
-    editingSubtaskIds.value = editingSubtaskIds.value.filter(id => id !== subtask.id);
-    listsStore.updateTodo(subtask);
+  editingSubtaskIds.value = editingSubtaskIds.value.filter(id => id !== subtask.id);
+  listsStore.updateTodo(subtask);
 }
 
 async function updatePriority(subtask: Todo, level: string) {
-    subtask.priorityLev = level;
-    listsStore.updateTodo(subtask);
+  subtask.priorityLev = level;
+  listsStore.updateTodo(subtask);
 }
 
 function toggleSort() {
-    subtasksSortBy.value = subtasksSortBy.value === 'priority' ? 'none' : 'priority';
+  subtasksSortBy.value = subtasksSortBy.value === 'priority' ? 'none' : 'priority';
 }
 
 function toggleStatus(subtask: Todo) {
-    subtask.status = subtask.status === 'Closed' ? 'Open' : 'Closed';
-    listsStore.updateTodo(subtask);
+  subtask.status = subtask.status === 'Closed' ? 'Open' : 'Closed';
+  listsStore.updateTodo(subtask);
 }
 
 function formatDueDate(date: Date | string | undefined): string {
-    if (!date) return '';
-    return new Date(date).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  if (!date) return '';
+  return new Date(date).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 </script>
 
 <template>
-    <section
-        class="subtasks"
-        data-testid="subtasks-section"
-    >
-        <!-- Header -->
-        <header class="subtasks__header">
-            <div class="subtasks__title-group">
-                <h3 class="subtasks__title">
-                    Subtasks
-                </h3>
-                <span
-                    v-if="total"
-                    class="subtasks__count"
-                    data-testid="subtasks-count"
-                >{{ doneCount }}/{{ total }}</span>
-            </div>
+  <section class="subtasks" data-testid="subtasks-section">
+    <!-- Header -->
+    <header class="subtasks__header">
 
-            <div class="subtasks__header-actions">
-                <v-tooltip
-                    v-if="total"
-                    location="bottom"
-                >
-                    <template #activator="{ props }">
-                        <button
-                            v-bind="props"
-                            type="button"
-                            class="subtasks__icon-btn"
-                            :class="{ 'subtasks__icon-btn--active': subtasksSortBy === 'priority' }"
-                            data-testid="subtasks-sort-button"
-                            @click="toggleSort"
-                        >
-                            <v-icon size="16">
-                                mdi-sort-variant
-                            </v-icon>
-                        </button>
-                    </template>
-                    <span>{{
-                        subtasksSortBy === 'priority'
-                            ? 'Sorted by priority — click to unsort'
-                            : 'Sort by priority'
-                    }}</span>
-                </v-tooltip>
+      <div class="subtasks__header-actions">
+        <v-tooltip v-if="total" location="bottom">
+          <template #activator="{ props }">
+            <button v-bind="props" type="button" class="subtasks__icon-btn"
+              :class="{ 'subtasks__icon-btn--active': subtasksSortBy === 'priority' }"
+              data-testid="subtasks-sort-button" @click="toggleSort">
+              <v-icon size="16">
+                mdi-sort-variant
+              </v-icon>
+            </button>
+          </template>
+          <span>{{
+            subtasksSortBy === 'priority'
+              ? 'Sorted by priority — click to unsort'
+              : 'Sort by priority'
+          }}</span>
+        </v-tooltip>
 
-                <button
-                    v-if="closedSubtasks.length"
-                    type="button"
-                    class="subtasks__ghost-btn"
-                    data-testid="subtasks-toggle-done"
-                    @click="showDone = !showDone"
-                >
-                    <v-icon size="14">
-                        {{
-                            showDone ? 'mdi-eye-outline' : 'mdi-eye-off-outline'
-                        }}
-                    </v-icon>
-                    {{ showDone ? 'Hide done' : 'Show done' }}
-                </button>
-            </div>
-        </header>
+        <button v-if="closedSubtasks.length" type="button" class="subtasks__ghost-btn"
+          data-testid="subtasks-toggle-done" @click="showDone = !showDone">
+          <v-icon size="14">
+            {{
+              showDone ? 'mdi-eye-outline' : 'mdi-eye-off-outline'
+            }}
+          </v-icon>
+          {{ showDone ? 'Hide done' : 'Show done' }}
+        </button>
+      </div>
+    </header>
 
-        <!-- Add subtask -->
-        <form
-            class="subtasks__add"
-            data-testid="add-subtask-form"
-            @submit.prevent="addSubtask"
-        >
-            <v-icon
-                class="subtasks__add-icon"
-                size="16"
-            >
-                mdi-plus
+    <!-- Add subtask -->
+    <form class="subtasks__add" data-testid="add-subtask-form" @submit.prevent="addSubtask">
+      <v-icon class="subtasks__add-icon" size="16">
+        mdi-plus
+      </v-icon>
+      <input v-model="newSubtaskName" type="text" placeholder="Add subtask" class="subtasks__add-input"
+        data-testid="add-subtask-input">
+      <kbd v-if="newSubtaskName" class="subtasks__kbd">↵</kbd>
+      <v-menu :width="400" location="bottom end">
+        <template #activator="{ props }">
+          <button v-bind="props" type="button" class="subtasks__icon-btn" data-testid="link-subtask-button" @click.stop>
+            <v-icon size="14">
+              mdi-link-variant
             </v-icon>
-            <input
-                v-model="newSubtaskName"
-                type="text"
-                placeholder="Add subtask"
-                class="subtasks__add-input"
-                data-testid="add-subtask-input"
-            >
-            <kbd
-                v-if="newSubtaskName"
-                class="subtasks__kbd"
-            >↵</kbd>
-            <v-menu
-                :width="400"
-                location="bottom end"
-            >
-                <template #activator="{ props }">
-                    <button
-                        v-bind="props"
-                        type="button"
-                        class="subtasks__icon-btn"
-                        data-testid="link-subtask-button"
-                        @click.stop
-                    >
-                        <v-icon size="14">
-                            mdi-link-variant
-                        </v-icon>
-                    </button>
-                </template>
-                <v-list density="compact">
-                    <v-list-item>
-                        <v-text-field
-                            v-model="linkSearch"
-                            placeholder="Search tasks"
-                            hide-details
-                            variant="outlined"
-                            density="compact"
-                            clearable
-                            data-testid="link-subtask-search"
-                            @click.stop
-                        />
-                    </v-list-item>
-                    <v-divider />
-                    <v-list-item
-                        v-for="todo in linkableTodos"
-                        :key="todo.id"
-                        :data-testid="`link-subtask-option-${todo.id}`"
-                        @click="linkExistingTodo(todo)"
-                    >
-                        <v-list-item-title>{{ todo.name }}</v-list-item-title>
-                    </v-list-item>
-                    <v-list-item v-if="!baseLinkableTodos.length">
-                        <v-list-item-title>No tasks available to link</v-list-item-title>
-                    </v-list-item>
-                    <v-list-item v-else-if="baseLinkableTodos.length && !linkableTodos.length">
-                        <v-list-item-title>No tasks match your search</v-list-item-title>
-                    </v-list-item>
-                </v-list>
-            </v-menu>
-        </form>
-
-        <!-- Active list -->
-        <ul
-            v-if="activeSubtasks.length"
-            class="subtasks__list"
-            data-testid="subtasks-list-active"
-        >
-            <li
-                v-for="(subtask, index) in activeSubtasks"
-                :key="subtask.id"
-                class="subtasks__row"
-                :data-testid="`subtask-item-${index}`"
-                @click="navigateToSubtask(subtask.id)"
-            >
-                <label
-                    class="subtasks__checkbox"
-                    @click.stop
-                >
-                    <input
-                        type="checkbox"
-                        :checked="false"
-                        :data-testid="`subtask-checkbox-${index}`"
-                        @change="toggleStatus(subtask)"
-                    >
-                    <span
-                        class="subtasks__checkbox-box"
-                        aria-hidden="true"
-                    />
-                </label>
-
-                <div class="subtasks__row-body">
-                    <div
-                        v-if="!isEditingSubtask(subtask.id)"
-                        class="subtasks__name"
-                        :data-testid="`subtask-name-${index}`"
-                    >
-                        {{ subtask.name }}
-                    </div>
-                    <input
-                        v-else
-                        :ref="(el) => (subtaskNameRefs[index] = el)"
-                        v-model="subtask.name"
-                        type="text"
-                        class="subtasks__name-input"
-                        :data-testid="`subtask-name-input-${index}`"
-                        @blur="onSubtaskBlur(subtask)"
-                        @click.stop
-                        @keyup.enter="onSubtaskBlur(subtask)"
-                    >
-                </div>
-
-                <span
-                    v-if="subtask.dueDate"
-                    class="subtasks__meta"
-                    :data-testid="`subtask-due-date-${index}`"
-                >
-                    <v-icon size="12">mdi-calendar-blank-outline</v-icon>
-                    {{ formatDueDate(subtask.dueDate) }}
-                </span>
-
-                <span
-                    v-if="subtask.githubBranchName"
-                    class="subtasks__meta subtasks__meta--mono"
-                    :data-testid="`subtask-branch-${index}`"
-                >
-                    <v-icon size="12">mdi-source-branch</v-icon>
-                    {{ subtask.githubBranchName }}
-                </span>
-
-                <div
-                    class="subtasks__priority-wrap"
-                    :class="{ 'subtasks__priority-wrap--set': subtask.priorityLev }"
-                    @click.stop
-                >
-                    <SubtaskPriority
-                        :subtask="subtask"
-                        :index="index"
-                        @update-priority="(level) => updatePriority(subtask, level)"
-                    />
-                </div>
-
-                <div
-                    class="subtasks__row-actions"
-                    @click.stop
-                >
-                    <v-menu>
-                        <template #activator="{ props }">
-                            <button
-                                v-bind="props"
-                                type="button"
-                                class="subtasks__icon-btn"
-                                :data-testid="`subtask-menu-${index}`"
-                                @click.stop
-                            >
-                                <v-icon size="14">
-                                    mdi-dots-horizontal
-                                </v-icon>
-                            </button>
-                        </template>
-                        <v-list density="compact">
-                            <v-list-item
-                                :data-testid="`subtask-rename-${index}`"
-                                @click="renameSubtask(subtask.id, index)"
-                            >
-                                <template #prepend>
-                                    <v-icon>mdi-pencil</v-icon>
-                                </template>
-                                <v-list-item-title>Rename subtask</v-list-item-title>
-                            </v-list-item>
-                            <v-list-item
-                                :data-testid="`subtask-delete-${index}`"
-                                @click="deleteSubtask(subtask.id)"
-                            >
-                                <template #prepend>
-                                    <v-icon color="error">
-                                        mdi-delete
-                                    </v-icon>
-                                </template>
-                                <v-list-item-title>Delete subtask</v-list-item-title>
-                            </v-list-item>
-                        </v-list>
-                    </v-menu>
-                </div>
-            </li>
-        </ul>
-
-        <p
-            v-if="!total"
-            class="subtasks__empty"
-        >
-            No subtasks yet. Add one above, or link an existing task.
-        </p>
-
-        <!-- Done group -->
-        <template v-if="showDone && closedSubtasks.length">
-            <div
-                class="subtasks__section-label"
-                data-testid="subtasks-done-label"
-            >
-                Done · {{ closedSubtasks.length }}
-            </div>
-            <ul
-                class="subtasks__list"
-                data-testid="subtasks-list-done"
-            >
-                <li
-                    v-for="(subtask, index) in closedSubtasks"
-                    :key="subtask.id"
-                    class="subtasks__row subtasks__row--done"
-                    :data-testid="`subtask-done-item-${index}`"
-                    @click="navigateToSubtask(subtask.id)"
-                >
-                    <label
-                        class="subtasks__checkbox"
-                        @click.stop
-                    >
-                        <input
-                            type="checkbox"
-                            :checked="true"
-                            :data-testid="`subtask-done-checkbox-${index}`"
-                            @change="toggleStatus(subtask)"
-                        >
-                        <span
-                            class="subtasks__checkbox-box subtasks__checkbox-box--checked"
-                            aria-hidden="true"
-                        >
-                            <v-icon
-                                size="10"
-                                color="white"
-                            >mdi-check</v-icon>
-                        </span>
-                    </label>
-
-                    <div class="subtasks__name subtasks__name--done">
-                        {{ subtask.name }}
-                    </div>
-
-                    <div
-                        class="subtasks__row-actions"
-                        @click.stop
-                    >
-                        <v-menu>
-                            <template #activator="{ props }">
-                                <button
-                                    v-bind="props"
-                                    type="button"
-                                    class="subtasks__icon-btn"
-                                    :data-testid="`subtask-done-menu-${index}`"
-                                    @click.stop
-                                >
-                                    <v-icon size="14">
-                                        mdi-dots-horizontal
-                                    </v-icon>
-                                </button>
-                            </template>
-                            <v-list density="compact">
-                                <v-list-item
-                                    :data-testid="`subtask-done-delete-${index}`"
-                                    @click="deleteSubtask(subtask.id)"
-                                >
-                                    <template #prepend>
-                                        <v-icon color="error">
-                                            mdi-delete
-                                        </v-icon>
-                                    </template>
-                                    <v-list-item-title>Delete subtask</v-list-item-title>
-                                </v-list-item>
-                            </v-list>
-                        </v-menu>
-                    </div>
-                </li>
-            </ul>
+          </button>
         </template>
-    </section>
+        <v-list density="compact">
+          <v-list-item>
+            <v-text-field v-model="linkSearch" placeholder="Search tasks" hide-details variant="outlined"
+              density="compact" clearable data-testid="link-subtask-search" @click.stop />
+          </v-list-item>
+          <v-divider />
+          <v-list-item v-for="todo in linkableTodos" :key="todo.id" :data-testid="`link-subtask-option-${todo.id}`"
+            @click="linkExistingTodo(todo)">
+            <v-list-item-title>{{ todo.name }}</v-list-item-title>
+          </v-list-item>
+          <v-list-item v-if="!baseLinkableTodos.length">
+            <v-list-item-title>No tasks available to link</v-list-item-title>
+          </v-list-item>
+          <v-list-item v-else-if="baseLinkableTodos.length && !linkableTodos.length">
+            <v-list-item-title>No tasks match your search</v-list-item-title>
+          </v-list-item>
+        </v-list>
+      </v-menu>
+    </form>
+
+    <!-- Active list -->
+    <ul v-if="activeSubtasks.length" class="subtasks__list" data-testid="subtasks-list-active">
+      <li v-for="(subtask, index) in activeSubtasks" :key="subtask.id" class="subtasks__row"
+        :data-testid="`subtask-item-${index}`" @click="navigateToSubtask(subtask.id)">
+        <label class="subtasks__checkbox" @click.stop>
+          <input type="checkbox" :checked="false" :data-testid="`subtask-checkbox-${index}`"
+            @change="toggleStatus(subtask)">
+          <span class="subtasks__checkbox-box" aria-hidden="true" />
+        </label>
+
+        <div class="subtasks__row-body">
+          <div v-if="!isEditingSubtask(subtask.id)" class="subtasks__name" :data-testid="`subtask-name-${index}`">
+            {{ subtask.name }}
+          </div>
+          <input v-else :ref="(el) => (subtaskNameRefs[index] = el)" v-model="subtask.name" type="text"
+            class="subtasks__name-input" :data-testid="`subtask-name-input-${index}`" @blur="onSubtaskBlur(subtask)"
+            @click.stop @keyup.enter="onSubtaskBlur(subtask)">
+        </div>
+
+        <span v-if="subtask.dueDate" class="subtasks__meta" :data-testid="`subtask-due-date-${index}`">
+          <v-icon size="12">mdi-calendar-blank-outline</v-icon>
+          {{ formatDueDate(subtask.dueDate) }}
+        </span>
+
+        <span v-if="subtask.githubBranchName" class="subtasks__meta subtasks__meta--mono"
+          :data-testid="`subtask-branch-${index}`">
+          <v-icon size="12">mdi-source-branch</v-icon>
+          {{ subtask.githubBranchName }}
+        </span>
+
+        <div class="subtasks__priority-wrap" :class="{ 'subtasks__priority-wrap--set': subtask.priorityLev }"
+          @click.stop>
+          <SubtaskPriority :subtask="subtask" :index="index"
+            @update-priority="(level) => updatePriority(subtask, level)" />
+        </div>
+
+        <div class="subtasks__row-actions" @click.stop>
+          <v-menu>
+            <template #activator="{ props }">
+              <button v-bind="props" type="button" class="subtasks__icon-btn" :data-testid="`subtask-menu-${index}`"
+                @click.stop>
+                <v-icon size="14">
+                  mdi-dots-horizontal
+                </v-icon>
+              </button>
+            </template>
+            <v-list density="compact">
+              <v-list-item :data-testid="`subtask-rename-${index}`" @click="renameSubtask(subtask.id, index)">
+                <template #prepend>
+                  <v-icon>mdi-pencil</v-icon>
+                </template>
+                <v-list-item-title>Rename subtask</v-list-item-title>
+              </v-list-item>
+              <v-list-item :data-testid="`subtask-delete-${index}`" @click="deleteSubtask(subtask.id)">
+                <template #prepend>
+                  <v-icon color="error">
+                    mdi-delete
+                  </v-icon>
+                </template>
+                <v-list-item-title>Delete subtask</v-list-item-title>
+              </v-list-item>
+            </v-list>
+          </v-menu>
+        </div>
+      </li>
+    </ul>
+
+    <p v-if="!total" class="subtasks__empty">
+      No subtasks yet. Add one above, or link an existing task.
+    </p>
+
+    <!-- Done group -->
+    <template v-if="showDone && closedSubtasks.length">
+      <div class="subtasks__section-label" data-testid="subtasks-done-label">
+        Done · {{ closedSubtasks.length }}
+      </div>
+      <ul class="subtasks__list" data-testid="subtasks-list-done">
+        <li v-for="(subtask, index) in closedSubtasks" :key="subtask.id" class="subtasks__row subtasks__row--done"
+          :data-testid="`subtask-done-item-${index}`" @click="navigateToSubtask(subtask.id)">
+          <label class="subtasks__checkbox" @click.stop>
+            <input type="checkbox" :checked="true" :data-testid="`subtask-done-checkbox-${index}`"
+              @change="toggleStatus(subtask)">
+            <span class="subtasks__checkbox-box subtasks__checkbox-box--checked" aria-hidden="true">
+              <v-icon size="10" color="white">mdi-check</v-icon>
+            </span>
+          </label>
+
+          <div class="subtasks__name subtasks__name--done">
+            {{ subtask.name }}
+          </div>
+
+          <div class="subtasks__row-actions" @click.stop>
+            <v-menu>
+              <template #activator="{ props }">
+                <button v-bind="props" type="button" class="subtasks__icon-btn"
+                  :data-testid="`subtask-done-menu-${index}`" @click.stop>
+                  <v-icon size="14">
+                    mdi-dots-horizontal
+                  </v-icon>
+                </button>
+              </template>
+              <v-list density="compact">
+                <v-list-item :data-testid="`subtask-done-delete-${index}`" @click="deleteSubtask(subtask.id)">
+                  <template #prepend>
+                    <v-icon color="error">
+                      mdi-delete
+                    </v-icon>
+                  </template>
+                  <v-list-item-title>Delete subtask</v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
+          </div>
+        </li>
+      </ul>
+    </template>
+  </section>
 </template>
 
 <style scoped>
 .subtasks {
-    --st-fg: #2a3439;
-    --st-fg-mid: rgba(42, 52, 57, 0.58);
-    --st-fg-low: rgba(42, 52, 57, 0.38);
-    --st-fg-faint: rgba(42, 52, 57, 0.22);
-    --st-border: rgba(113, 124, 130, 0.16);
-    --st-hover: rgba(113, 124, 130, 0.07);
-    --st-paper: #f7f9fb;
-    --st-primary: #005ac2;
-    font-family: 'Inter', sans-serif;
-    color: var(--st-fg);
+  --st-fg: #2a3439;
+  --st-fg-mid: rgba(42, 52, 57, 0.58);
+  --st-fg-low: rgba(42, 52, 57, 0.38);
+  --st-fg-faint: rgba(42, 52, 57, 0.22);
+  --st-border: rgba(113, 124, 130, 0.16);
+  --st-hover: rgba(113, 124, 130, 0.07);
+  --st-paper: #f7f9fb;
+  --st-primary: #005ac2;
+  font-family: 'Inter', sans-serif;
+  color: var(--st-fg);
 }
 
 /* Header */
 .subtasks__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
 }
 
 .subtasks__title-group {
-    display: flex;
-    align-items: baseline;
-    gap: 8px;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
 }
 
 .subtasks__title {
-    font-family: 'Manrope', sans-serif;
-    font-size: 0.9375rem;
-    font-weight: 700;
-    color: var(--st-fg);
-    margin: 0;
+  font-family: 'Manrope', sans-serif;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--st-fg);
+  margin: 0;
 }
 
 .subtasks__count {
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--st-fg-mid);
-    font-variant-numeric: tabular-nums;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--st-fg-mid);
+  font-variant-numeric: tabular-nums;
 }
 
 .subtasks__header-actions {
-    display: flex;
-    align-items: center;
-    gap: 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
 .subtasks__ghost-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    padding: 4px 8px;
-    border-radius: 6px;
-    font-family: inherit;
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: var(--st-fg-mid);
-    transition:
-        background 0.12s,
-        color 0.12s;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--st-fg-mid);
+  transition:
+    background 0.12s,
+    color 0.12s;
 }
 
 .subtasks__ghost-btn:hover {
-    background: var(--st-hover);
-    color: var(--st-fg);
+  background: var(--st-hover);
+  color: var(--st-fg);
 }
 
 .subtasks__icon-btn {
-    width: 24px;
-    height: 24px;
-    border: none;
-    background: transparent;
-    border-radius: 5px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    color: var(--st-fg-mid);
-    padding: 0;
-    transition:
-        background 0.12s,
-        color 0.12s;
-    flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  border-radius: 5px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--st-fg-mid);
+  padding: 0;
+  transition:
+    background 0.12s,
+    color 0.12s;
+  flex-shrink: 0;
 }
 
 .subtasks__icon-btn:hover {
-    background: var(--st-hover);
-    color: var(--st-fg);
+  background: var(--st-hover);
+  color: var(--st-fg);
 }
 
 .subtasks__icon-btn--active {
-    color: var(--st-primary);
-    background: rgba(0, 90, 194, 0.1);
+  color: var(--st-primary);
+  background: rgba(0, 90, 194, 0.1);
 }
 
 /* Add row */
 .subtasks__add {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 10px 12px;
-    border-radius: 8px;
-    background: var(--st-paper);
-    margin-bottom: 8px;
-    transition: box-shadow 0.12s;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--st-paper);
+  margin-bottom: 8px;
+  transition: box-shadow 0.12s;
 }
 
 .subtasks__add:focus-within {
-    box-shadow: 0 0 0 2px rgba(0, 90, 194, 0.18);
+  box-shadow: 0 0 0 2px rgba(0, 90, 194, 0.18);
 }
 
 .subtasks__add-icon {
-    color: var(--st-fg-low);
-    flex-shrink: 0;
+  color: var(--st-fg-low);
+  flex-shrink: 0;
 }
 
 .subtasks__add-input {
-    flex: 1;
-    border: none;
-    outline: none;
-    background: transparent;
-    font-family: inherit;
-    font-size: 0.875rem;
-    color: var(--st-fg);
-    min-width: 0;
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 0.875rem;
+  color: var(--st-fg);
+  min-width: 0;
 }
 
 .subtasks__add-input::placeholder {
-    color: var(--st-fg-low);
+  color: var(--st-fg-low);
 }
 
 .subtasks__kbd {
-    font-family: inherit;
-    font-size: 0.6875rem;
-    color: var(--st-fg-low);
-    padding: 2px 6px;
-    border: 1px solid var(--st-border);
-    border-radius: 4px;
-    background: #fff;
+  font-family: inherit;
+  font-size: 0.6875rem;
+  color: var(--st-fg-low);
+  padding: 2px 6px;
+  border: 1px solid var(--st-border);
+  border-radius: 4px;
+  background: #fff;
 }
 
 /* Rows */
 .subtasks__list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .subtasks__row {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 8px;
-    margin: 0 -8px;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: background 0.12s;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px;
+  margin: 0 -8px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s;
 }
 
 .subtasks__row:hover {
-    background: var(--st-hover);
+  background: var(--st-hover);
 }
 
 .subtasks__row:hover .subtasks__row-actions {
-    opacity: 1;
+  opacity: 1;
 }
 
 .subtasks__row:hover .subtasks__priority-wrap {
-    opacity: 1;
+  opacity: 1;
 }
 
 .subtasks__row--done .subtasks__name {
-    color: var(--st-fg-low);
-    text-decoration: line-through;
+  color: var(--st-fg-low);
+  text-decoration: line-through;
 }
 
 .subtasks__row-body {
-    flex: 1;
-    min-width: 0;
+  flex: 1;
+  min-width: 0;
 }
 
 .subtasks__name {
-    font-size: 0.875rem;
-    color: var(--st-fg);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  font-size: 0.875rem;
+  color: var(--st-fg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .subtasks__name--done {
-    color: var(--st-fg-low);
-    text-decoration: line-through;
+  color: var(--st-fg-low);
+  text-decoration: line-through;
 }
 
 .subtasks__name-input {
-    width: 100%;
-    border: none;
-    outline: none;
-    background: transparent;
-    font: inherit;
-    font-size: 0.875rem;
-    color: var(--st-fg);
-    padding: 0;
+  width: 100%;
+  border: none;
+  outline: none;
+  background: transparent;
+  font: inherit;
+  font-size: 0.875rem;
+  color: var(--st-fg);
+  padding: 0;
 }
 
 .subtasks__meta {
-    font-size: 0.75rem;
-    color: var(--st-fg-mid);
-    display: inline-flex;
-    align-items: center;
-    gap: 3px;
-    flex-shrink: 0;
+  font-size: 0.75rem;
+  color: var(--st-fg-mid);
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
 }
 
 .subtasks__meta--mono {
-    font-family: ui-monospace, 'Cascadia Code', Menlo, monospace;
-    font-size: 0.6875rem;
+  font-family: ui-monospace, 'Cascadia Code', Menlo, monospace;
+  font-size: 0.6875rem;
 }
 
 .subtasks__priority-wrap {
-    opacity: 0;
-    transition: opacity 0.12s;
-    flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.12s;
+  flex-shrink: 0;
 }
 
 .subtasks__priority-wrap--set {
-    opacity: 1;
+  opacity: 1;
 }
 
 .subtasks__row-actions {
-    display: flex;
-    align-items: center;
-    gap: 2px;
-    opacity: 0;
-    transition: opacity 0.12s;
-    flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.12s;
+  flex-shrink: 0;
 }
 
 /* Checkbox */
 .subtasks__checkbox {
-    position: relative;
-    width: 16px;
-    height: 16px;
-    flex-shrink: 0;
-    cursor: pointer;
-    display: inline-flex;
+  position: relative;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  cursor: pointer;
+  display: inline-flex;
 }
 
 .subtasks__checkbox input {
-    position: absolute;
-    inset: 0;
-    opacity: 0;
-    margin: 0;
-    cursor: pointer;
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  margin: 0;
+  cursor: pointer;
 }
 
 .subtasks__checkbox-box {
-    width: 16px;
-    height: 16px;
-    border-radius: 4px;
-    border: 1.5px solid var(--st-fg-faint);
-    background: transparent;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    transition: all 0.15s;
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  border: 1.5px solid var(--st-fg-faint);
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
 }
 
 .subtasks__checkbox-box--checked {
-    border-color: var(--st-primary);
-    background: var(--st-primary);
+  border-color: var(--st-primary);
+  background: var(--st-primary);
 }
 
 .subtasks__checkbox:hover .subtasks__checkbox-box {
-    border-color: var(--st-primary);
+  border-color: var(--st-primary);
 }
 
 /* Done section */
 .subtasks__section-label {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    color: var(--st-fg-low);
-    padding: 14px 0 4px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--st-fg-low);
+  padding: 14px 0 4px;
 }
 
 .subtasks__empty {
-    font-size: 0.8125rem;
-    color: var(--st-fg-mid);
-    padding: 12px 0 0;
-    margin: 0;
+  font-size: 0.8125rem;
+  color: var(--st-fg-mid);
+  padding: 12px 0 0;
+  margin: 0;
 }
 </style>

--- a/app/components/Subtasks.vue
+++ b/app/components/Subtasks.vue
@@ -1,0 +1,319 @@
+<script setup lang="ts">
+const listsStore = useListsStore();
+const subtaskTotal = computed(() => listsStore.currentTodo.subtasks?.length ?? 0);
+const subtaskDone = computed(
+  () => listsStore.currentTodo.subtasks?.filter(s => s.status === 'Closed').length ?? 0,
+);
+const subtaskPct = computed(() =>
+  subtaskTotal.value ? Math.round((subtaskDone.value / subtaskTotal.value) * 100) : 0,
+);
+const allDone = computed(() => subtaskTotal.value > 0 && subtaskPct.value === 100);
+
+</script>
+<template>
+  <div class="main-section">
+    <div class="subtasks-header">
+      <div class="subtasks-header__left">
+        <span class="section-label">Subtasks</span>
+        <span v-if="subtaskTotal" class="subtasks-badge" :class="{ 'subtasks-badge--done': allDone }">
+          {{ subtaskDone }}/{{ subtaskTotal }}
+        </span>
+      </div>
+      <div v-if="subtaskTotal" class="subtasks-progress">
+        <div class="subtasks-progress__bar" :class="{ 'subtasks-progress__bar--done': allDone }"
+          :style="{ width: subtaskPct + '%' }" />
+      </div>
+    </div>
+    <Subtask />
+  </div>
+</template>
+<style scoped>
+.todo-detail {
+  width: 100%;
+  padding-bottom: 40px;
+}
+
+/* Two-column grid: left fluid, right fixed 248px */
+.todo-layout {
+  display: grid;
+  grid-template-columns: 1fr 248px;
+  gap: 20px;
+  align-items: start;
+}
+
+/* Stack vertically on mobile */
+@media (max-width: 959px) {
+  .todo-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .todo-sidebar {
+    order: -1;
+  }
+}
+
+/* LEFT column */
+.todo-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(42, 52, 57, 0.06);
+  padding-bottom: 8px;
+}
+
+.main-section {
+  padding: 12px 20px;
+}
+
+.main-section--title {
+  padding: 18px 20px 10px;
+}
+
+.divider {
+  height: 1px;
+  background: rgba(var(--v-border-color), 0.14);
+  margin: 0 20px;
+}
+
+/* Title input */
+.title-input {
+  width: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-family: 'Manrope', sans-serif;
+  font-size: 1.3125rem;
+  font-weight: 700;
+  color: rgb(var(--v-theme-on-surface));
+  line-height: 1.3;
+  padding: 2px 0;
+  resize: none;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.title-input:focus {
+  outline: 2px solid rgb(var(--v-theme-primary));
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Section label */
+.section-label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(var(--v-theme-on-surface), 0.45);
+  margin-bottom: 8px;
+}
+
+/* Description textarea */
+.desc-textarea {
+  width: 100%;
+  min-height: 80px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: rgb(var(--v-theme-on-surface));
+  font-size: 0.9rem;
+  font-family: inherit;
+  line-height: 1.6;
+  resize: none;
+  outline: none;
+}
+
+.desc-textarea::placeholder {
+  color: rgba(var(--v-theme-on-surface), 0.35);
+}
+
+/* Subtasks header */
+.subtasks-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.subtasks-header__left {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.subtasks-badge {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  background: rgb(var(--v-theme-primary-container));
+  color: rgb(var(--v-theme-on-primary-container));
+  padding: 1px 7px;
+  border-radius: 8px;
+  transition: background 0.2s, color 0.2s;
+}
+
+.subtasks-badge--done {
+  background: rgba(26, 122, 74, 0.12);
+  color: #1a7a4a;
+}
+
+.subtasks-progress {
+  width: 64px;
+  height: 3px;
+  border-radius: 2px;
+  background: rgba(var(--v-border-color), 0.2);
+  overflow: hidden;
+}
+
+.subtasks-progress__bar {
+  height: 100%;
+  border-radius: 2px;
+  background: rgb(var(--v-theme-primary));
+  transition: width 0.3s ease, background 0.3s;
+}
+
+.subtasks-progress__bar--done {
+  background: #1a7a4a;
+}
+
+/* RIGHT sidebar */
+.todo-sidebar {
+  position: sticky;
+  top: 16px;
+}
+
+.sidebar-card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(42, 52, 57, 0.06);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+/* Property rows */
+.prop-row {
+  display: flex;
+  align-items: center;
+  min-height: 32px;
+}
+
+.prop-row__label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  width: 80px;
+  flex-shrink: 0;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: rgba(var(--v-theme-on-surface), 0.5);
+  user-select: none;
+}
+
+.prop-row__icon {
+  font-size: 14px;
+  width: 16px;
+  text-align: center;
+  opacity: 0.6;
+}
+
+.prop-row__value {
+  flex: 1;
+  font-size: 0.875rem;
+  min-width: 0;
+}
+
+.prop-row__value--plain {
+  color: rgb(var(--v-theme-on-surface));
+  font-size: 0.875rem;
+}
+
+.prop-row__value--overdue :deep(*) {
+  color: #ba1b24 !important;
+  font-weight: 500;
+}
+
+/* Status pill */
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px 3px 7px;
+  border-radius: 20px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  font-family: inherit;
+  transition: opacity 0.15s;
+  white-space: nowrap;
+}
+
+.status-pill:hover {
+  opacity: 0.8;
+}
+
+.status-pill__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.status-pill__chevron {
+  font-size: 12px;
+  opacity: 0.7;
+}
+
+.pop-menu {
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  min-width: 140px;
+  background: rgb(var(--v-theme-surface));
+  border: 1px solid rgba(var(--v-border-color), 0.12);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+}
+
+.pop-menu__item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  transition: background 0.1s;
+}
+
+.pop-menu__item:hover {
+  background: rgba(var(--v-border-color), 0.08);
+}
+
+.pop-menu__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* Sidebar divider and delete */
+.sidebar-divider {
+  height: 1px;
+  background: rgba(var(--v-border-color), 0.14);
+  margin: 8px 0;
+}
+
+.sidebar-delete {
+  display: flex;
+  justify-content: flex-start;
+}
+
+.delete-btn {
+  padding-left: 0 !important;
+  font-size: 0.8125rem;
+}
+</style>

--- a/app/components/Todo/Detail.vue
+++ b/app/components/Todo/Detail.vue
@@ -34,14 +34,6 @@ function updateDueDate(newDate: Date) {
   listsStore.updateTodo(listsStore.currentTodo);
 }
 
-const subtaskTotal = computed(() => listsStore.currentTodo.subtasks?.length ?? 0);
-const subtaskDone = computed(
-  () => listsStore.currentTodo.subtasks?.filter(s => s.status === 'Closed').length ?? 0,
-);
-const subtaskPct = computed(() =>
-  subtaskTotal.value ? Math.round((subtaskDone.value / subtaskTotal.value) * 100) : 0,
-);
-const allDone = computed(() => subtaskTotal.value > 0 && subtaskPct.value === 100);
 
 async function deleteTodo() {
   if (!listsStore.currentTodo?.id) return;
@@ -79,22 +71,7 @@ async function deleteTodo() {
 
         <div class="divider" />
 
-        <!-- Subtasks -->
-        <div class="main-section">
-          <div class="subtasks-header">
-            <div class="subtasks-header__left">
-              <span class="section-label">Subtasks</span>
-              <span v-if="subtaskTotal" class="subtasks-badge" :class="{ 'subtasks-badge--done': allDone }">
-                {{ subtaskDone }}/{{ subtaskTotal }}
-              </span>
-            </div>
-            <div v-if="subtaskTotal" class="subtasks-progress">
-              <div class="subtasks-progress__bar" :class="{ 'subtasks-progress__bar--done': allDone }"
-                :style="{ width: subtaskPct + '%' }" />
-            </div>
-          </div>
-          <Subtask />
-        </div>
+        <Subtasks />
 
         <div class="divider" />
 

--- a/app/components/Todo/Detail.vue
+++ b/app/components/Todo/Detail.vue
@@ -49,7 +49,8 @@ async function deleteTodo() {
     await listsStore.deleteTodo(listsStore.currentTodo.id);
     if (listId) {
         router.push(`/list/${listId}`);
-    } else {
+    }
+    else {
         router.push('/');
     }
 }
@@ -101,7 +102,10 @@ async function deleteTodo() {
                                 {{ subtaskDone }}/{{ subtaskTotal }}
                             </span>
                         </div>
-                        <div v-if="subtaskTotal" class="subtasks-progress">
+                        <div
+                            v-if="subtaskTotal"
+                            class="subtasks-progress"
+                        >
                             <div
                                 class="subtasks-progress__bar"
                                 :class="{ 'subtasks-progress__bar--done': allDone }"
@@ -176,7 +180,10 @@ async function deleteTodo() {
                             <i class="mdi mdi-calendar prop-row__icon" />
                             <span>Due date</span>
                         </div>
-                        <div class="prop-row__value" :class="{ 'prop-row__value--overdue': isOverdue }">
+                        <div
+                            class="prop-row__value"
+                            :class="{ 'prop-row__value--overdue': isOverdue }"
+                        >
                             <AppDueDate
                                 :todo="listsStore.currentTodo"
                                 :todo-due-date="listsStore.currentTodo.dueDate"
@@ -198,7 +205,10 @@ async function deleteTodo() {
                     </div>
 
                     <!-- GitHub (conditional) -->
-                    <div v-if="hasGithub" class="prop-row">
+                    <div
+                        v-if="hasGithub"
+                        class="prop-row"
+                    >
                         <div class="prop-row__label">
                             <i class="mdi mdi-github prop-row__icon" />
                             <span>GitHub</span>
@@ -232,7 +242,10 @@ async function deleteTodo() {
                                     </v-card-text>
                                     <v-card-actions>
                                         <v-spacer />
-                                        <v-btn color="error" @click="deleteTodo">
+                                        <v-btn
+                                            color="error"
+                                            @click="deleteTodo"
+                                        >
                                             Delete
                                         </v-btn>
                                         <v-btn @click="isActive.value = false">

--- a/app/components/Todo/Detail.vue
+++ b/app/components/Todo/Detail.vue
@@ -5,550 +5,489 @@ const router = useRouter();
 const hasGithub = await useHasGithub();
 
 function updateName() {
-    if (listsStore.currentTodo.name) {
-        listsStore.updateTodo(listsStore.currentTodo);
-    }
+  if (listsStore.currentTodo.name) {
+    listsStore.updateTodo(listsStore.currentTodo);
+  }
 }
 
 const currentStatus = computed(
-    () => statuses.find(s => s.name === listsStore.currentTodo.status) ?? statuses[0],
+  () => statuses.find(s => s.name === listsStore.currentTodo.status) ?? statuses[0],
 );
 
 function setStatus(status: Status) {
-    listsStore.currentTodo.status = status.name;
-    listsStore.updateTodo(listsStore.currentTodo);
+  listsStore.currentTodo.status = status.name;
+  listsStore.updateTodo(listsStore.currentTodo);
 }
 
 const today = new Date();
 today.setHours(0, 0, 0, 0);
 
 const isOverdue = computed(() => {
-    if (!listsStore.currentTodo.dueDate) return false;
-    const d = new Date(listsStore.currentTodo.dueDate);
-    d.setHours(0, 0, 0, 0);
-    return d < today && listsStore.currentTodo.status !== 'Closed';
+  if (!listsStore.currentTodo.dueDate) return false;
+  const d = new Date(listsStore.currentTodo.dueDate);
+  d.setHours(0, 0, 0, 0);
+  return d < today && listsStore.currentTodo.status !== 'Closed';
 });
 
 function updateDueDate(newDate: Date) {
-    listsStore.currentTodo.dueDate = newDate;
-    listsStore.updateTodo(listsStore.currentTodo);
+  listsStore.currentTodo.dueDate = newDate;
+  listsStore.updateTodo(listsStore.currentTodo);
 }
 
 const subtaskTotal = computed(() => listsStore.currentTodo.subtasks?.length ?? 0);
 const subtaskDone = computed(
-    () => listsStore.currentTodo.subtasks?.filter(s => s.status === 'Closed').length ?? 0,
+  () => listsStore.currentTodo.subtasks?.filter(s => s.status === 'Closed').length ?? 0,
 );
 const subtaskPct = computed(() =>
-    subtaskTotal.value ? Math.round((subtaskDone.value / subtaskTotal.value) * 100) : 0,
+  subtaskTotal.value ? Math.round((subtaskDone.value / subtaskTotal.value) * 100) : 0,
 );
 const allDone = computed(() => subtaskTotal.value > 0 && subtaskPct.value === 100);
 
 async function deleteTodo() {
-    if (!listsStore.currentTodo?.id) return;
-    const listId = listsStore.currentTodo.listId;
-    await listsStore.deleteTodo(listsStore.currentTodo.id);
-    if (listId) {
-        router.push(`/list/${listId}`);
-    }
-    else {
-        router.push('/');
-    }
+  if (!listsStore.currentTodo?.id) return;
+  const listId = listsStore.currentTodo.listId;
+  await listsStore.deleteTodo(listsStore.currentTodo.id);
+  if (listId) {
+    router.push(`/list/${listId}`);
+  } else {
+    router.push('/');
+  }
 }
 </script>
 
 <template>
-    <div class="todo-detail">
-        <!-- Two-column layout wrapper -->
-        <div class="todo-layout">
-            <!-- LEFT: main content -->
-            <div class="todo-main">
-                <!-- Title -->
-                <div class="main-section main-section--title">
-                    <textarea
-                        v-model="listsStore.currentTodo.name"
-                        class="title-input"
-                        data-testid="todo-detail-title"
-                        rows="1"
-                        @blur="updateName"
-                    />
-                </div>
-
-                <!-- Description -->
-                <div class="main-section">
-                    <div class="section-label">
-                        Description
-                    </div>
-                    <textarea
-                        v-model="listsStore.currentTodo.desc"
-                        class="desc-textarea"
-                        placeholder="Add a description…"
-                        @input="listsStore.debounceUpdateTodo(listsStore.currentTodo)"
-                        @blur="listsStore.updateTodo(listsStore.currentTodo)"
-                    />
-                </div>
-
-                <div class="divider" />
-
-                <!-- Subtasks -->
-                <div class="main-section">
-                    <div class="subtasks-header">
-                        <div class="subtasks-header__left">
-                            <span class="section-label">Subtasks</span>
-                            <span
-                                v-if="subtaskTotal"
-                                class="subtasks-badge"
-                                :class="{ 'subtasks-badge--done': allDone }"
-                            >
-                                {{ subtaskDone }}/{{ subtaskTotal }}
-                            </span>
-                        </div>
-                        <div
-                            v-if="subtaskTotal"
-                            class="subtasks-progress"
-                        >
-                            <div
-                                class="subtasks-progress__bar"
-                                :class="{ 'subtasks-progress__bar--done': allDone }"
-                                :style="{ width: subtaskPct + '%' }"
-                            />
-                        </div>
-                    </div>
-                    <Subtask />
-                </div>
-
-                <div class="divider" />
-
-                <!-- Links -->
-                <div class="main-section">
-                    <div class="section-label">
-                        Links
-                    </div>
-                    <TodoLinks />
-                </div>
-            </div>
-
-            <!-- RIGHT: sidebar -->
-            <aside class="todo-sidebar">
-                <div class="sidebar-card">
-                    <!-- Status -->
-                    <div class="prop-row">
-                        <div class="prop-row__label">
-                            <i class="mdi mdi-circle-slice-4 prop-row__icon" />
-                            <span>Status</span>
-                        </div>
-                        <div class="prop-row__value">
-                            <v-menu>
-                                <template #activator="{ props }">
-                                    <button
-                                        v-bind="props"
-                                        class="status-pill"
-                                        :style="{
-                                            background: `${currentStatus.color}18`,
-                                            color: currentStatus.color,
-                                            borderColor: `${currentStatus.color}33`,
-                                        }"
-                                    >
-                                        <span
-                                            class="status-pill__dot"
-                                            :style="{ background: currentStatus.color }"
-                                        />
-                                        {{ listsStore.currentTodo.status }}
-                                        <i class="mdi mdi-chevron-down status-pill__chevron" />
-                                    </button>
-                                </template>
-                                <ul class="pop-menu">
-                                    <li
-                                        v-for="s in statuses"
-                                        :key="s.name"
-                                        class="pop-menu__item"
-                                        @click="setStatus(s)"
-                                    >
-                                        <span
-                                            class="pop-menu__dot"
-                                            :style="{ background: s.color }"
-                                        />
-                                        {{ s.name }}
-                                    </li>
-                                </ul>
-                            </v-menu>
-                        </div>
-                    </div>
-
-                    <!-- Due date -->
-                    <div class="prop-row">
-                        <div class="prop-row__label">
-                            <i class="mdi mdi-calendar prop-row__icon" />
-                            <span>Due date</span>
-                        </div>
-                        <div
-                            class="prop-row__value"
-                            :class="{ 'prop-row__value--overdue': isOverdue }"
-                        >
-                            <AppDueDate
-                                :todo="listsStore.currentTodo"
-                                :todo-due-date="listsStore.currentTodo.dueDate"
-                                :show-detail="true"
-                                @set-date="updateDueDate"
-                            />
-                        </div>
-                    </div>
-
-                    <!-- List -->
-                    <div class="prop-row">
-                        <div class="prop-row__label">
-                            <i class="mdi mdi-format-list-bulleted prop-row__icon" />
-                            <span>List</span>
-                        </div>
-                        <div class="prop-row__value prop-row__value--plain">
-                            {{ listsStore.currentList?.name }}
-                        </div>
-                    </div>
-
-                    <!-- GitHub (conditional) -->
-                    <div
-                        v-if="hasGithub"
-                        class="prop-row"
-                    >
-                        <div class="prop-row__label">
-                            <i class="mdi mdi-github prop-row__icon" />
-                            <span>GitHub</span>
-                        </div>
-                        <div class="prop-row__value">
-                            <GithubButton :todo="listsStore.currentTodo" />
-                        </div>
-                    </div>
-
-                    <div class="sidebar-divider" />
-
-                    <!-- Delete -->
-                    <div class="sidebar-delete">
-                        <v-dialog width="260px">
-                            <template #activator="{ props: activatorProps }">
-                                <v-btn
-                                    v-bind="activatorProps"
-                                    color="error"
-                                    variant="text"
-                                    prepend-icon="mdi-trash-can-outline"
-                                    size="small"
-                                    class="delete-btn"
-                                >
-                                    Delete todo
-                                </v-btn>
-                            </template>
-                            <template #default="{ isActive }">
-                                <v-card rounded="lg">
-                                    <v-card-text>
-                                        Are you sure you want to delete this todo?
-                                    </v-card-text>
-                                    <v-card-actions>
-                                        <v-spacer />
-                                        <v-btn
-                                            color="error"
-                                            @click="deleteTodo"
-                                        >
-                                            Delete
-                                        </v-btn>
-                                        <v-btn @click="isActive.value = false">
-                                            Cancel
-                                        </v-btn>
-                                    </v-card-actions>
-                                </v-card>
-                            </template>
-                        </v-dialog>
-                    </div>
-                </div>
-            </aside>
+  <div class="todo-detail">
+    <!-- Two-column layout wrapper -->
+    <div class="todo-layout">
+      <!-- LEFT: main content -->
+      <div class="todo-main">
+        <!-- Title -->
+        <div class="main-section main-section--title">
+          <textarea v-model="listsStore.currentTodo.name" class="title-input" data-testid="todo-detail-title" rows="1"
+            @blur="updateName" />
         </div>
+
+        <!-- Description -->
+        <div class="main-section">
+          <div class="section-label">
+            Description
+          </div>
+          <textarea v-model="listsStore.currentTodo.desc" class="desc-textarea" placeholder="Add a description…"
+            @input="listsStore.debounceUpdateTodo(listsStore.currentTodo)"
+            @blur="listsStore.updateTodo(listsStore.currentTodo)" />
+        </div>
+
+        <div class="divider" />
+
+        <!-- Subtasks -->
+        <div class="main-section">
+          <div class="subtasks-header">
+            <div class="subtasks-header__left">
+              <span class="section-label">Subtasks</span>
+              <span v-if="subtaskTotal" class="subtasks-badge" :class="{ 'subtasks-badge--done': allDone }">
+                {{ subtaskDone }}/{{ subtaskTotal }}
+              </span>
+            </div>
+            <div v-if="subtaskTotal" class="subtasks-progress">
+              <div class="subtasks-progress__bar" :class="{ 'subtasks-progress__bar--done': allDone }"
+                :style="{ width: subtaskPct + '%' }" />
+            </div>
+          </div>
+          <Subtask />
+        </div>
+
+        <div class="divider" />
+
+        <!-- Links -->
+        <div class="main-section">
+          <div class="section-label">
+            Links
+          </div>
+          <TodoLinks />
+        </div>
+      </div>
+
+      <aside class="todo-sidebar">
+        <div class="sidebar-card">
+          <div class="prop-row">
+            <div class="prop-row__label">
+              <i class="mdi mdi-circle-slice-4 prop-row__icon" />
+              <span>Status</span>
+            </div>
+            <div class="prop-row__value">
+              <v-menu>
+                <template #activator="{ props }">
+                  <button v-bind="props" class="status-pill" :style="{
+                    background: `${currentStatus.color}18`,
+                    color: currentStatus.color,
+                    borderColor: `${currentStatus.color}33`,
+                  }">
+                    <span class="status-pill__dot" :style="{ background: currentStatus.color }" />
+                    {{ listsStore.currentTodo.status }}
+                    <i class="mdi mdi-chevron-down status-pill__chevron" />
+                  </button>
+                </template>
+                <ul class="pop-menu">
+                  <li v-for="s in statuses" :key="s.name" class="pop-menu__item" @click="setStatus(s)">
+                    <span class="pop-menu__dot" :style="{ background: s.color }" />
+                    {{ s.name }}
+                  </li>
+                </ul>
+              </v-menu>
+            </div>
+          </div>
+
+          <div class="prop-row">
+            <div class="prop-row__label">
+              <i class="mdi mdi-calendar prop-row__icon" />
+              <span>Due date</span>
+            </div>
+            <div class="prop-row__value" :class="{ 'prop-row__value--overdue': isOverdue }">
+              <AppDueDate :todo="listsStore.currentTodo" :todo-due-date="listsStore.currentTodo.dueDate"
+                :show-detail="true" @set-date="updateDueDate" />
+            </div>
+          </div>
+          <div class="prop-row">
+            <div class="prop-row__label">
+              <i class="mdi mdi-format-list-bulleted prop-row__icon" />
+              <span>List</span>
+            </div>
+            <div class="prop-row__value prop-row__value--plain">
+              {{ listsStore.currentList?.name }}
+            </div>
+          </div>
+
+          <div v-if="hasGithub" class="prop-row">
+            <div class="prop-row__label">
+              <i class="mdi mdi-github prop-row__icon" />
+              <span>GitHub</span>
+            </div>
+            <div class="prop-row__value">
+              <GithubButton :todo="listsStore.currentTodo" />
+            </div>
+          </div>
+
+          <div class="sidebar-divider" />
+
+          <div class="sidebar-delete">
+            <v-dialog width="260px">
+              <template #activator="{ props: activatorProps }">
+                <v-btn v-bind="activatorProps" color="error" variant="text" prepend-icon="mdi-trash-can-outline"
+                  size="small" class="delete-btn">
+                  Delete todo
+                </v-btn>
+              </template>
+              <template #default="{ isActive }">
+                <v-card rounded="lg">
+                  <v-card-text>
+                    Are you sure you want to delete this todo?
+                  </v-card-text>
+                  <v-card-actions>
+                    <v-spacer />
+                    <v-btn color="error" @click="deleteTodo">
+                      Delete
+                    </v-btn>
+                    <v-btn @click="isActive.value = false">
+                      Cancel
+                    </v-btn>
+                  </v-card-actions>
+                </v-card>
+              </template>
+            </v-dialog>
+          </div>
+        </div>
+      </aside>
     </div>
+  </div>
 </template>
 
 <style scoped>
 .todo-detail {
-    width: 100%;
-    padding-bottom: 40px;
+  width: 100%;
+  padding-bottom: 40px;
 }
 
 /* Two-column grid: left fluid, right fixed 248px */
 .todo-layout {
-    display: grid;
-    grid-template-columns: 1fr 248px;
-    gap: 20px;
-    align-items: start;
+  display: grid;
+  grid-template-columns: 1fr 248px;
+  gap: 20px;
+  align-items: start;
 }
 
 /* Stack vertically on mobile */
 @media (max-width: 959px) {
-    .todo-layout {
-        grid-template-columns: 1fr;
-    }
+  .todo-layout {
+    grid-template-columns: 1fr;
+  }
 
-    .todo-sidebar {
-        order: -1;
-    }
+  .todo-sidebar {
+    order: -1;
+  }
 }
 
 /* LEFT column */
 .todo-main {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    background: #fff;
-    border-radius: 8px;
-    box-shadow: 0 8px 32px rgba(42, 52, 57, 0.06);
-    padding-bottom: 8px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(42, 52, 57, 0.06);
+  padding-bottom: 8px;
 }
 
 .main-section {
-    padding: 12px 20px;
+  padding: 12px 20px;
 }
 
 .main-section--title {
-    padding: 18px 20px 10px;
+  padding: 18px 20px 10px;
 }
 
 .divider {
-    height: 1px;
-    background: rgba(var(--v-border-color), 0.14);
-    margin: 0 20px;
+  height: 1px;
+  background: rgba(var(--v-border-color), 0.14);
+  margin: 0 20px;
 }
 
 /* Title input */
 .title-input {
-    width: 100%;
-    background: transparent;
-    border: none;
-    outline: none;
-    font-family: 'Manrope', sans-serif;
-    font-size: 1.3125rem;
-    font-weight: 700;
-    color: rgb(var(--v-theme-on-surface));
-    line-height: 1.3;
-    padding: 2px 0;
-    resize: none;
-    box-sizing: border-box;
-    overflow: hidden;
+  width: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-family: 'Manrope', sans-serif;
+  font-size: 1.3125rem;
+  font-weight: 700;
+  color: rgb(var(--v-theme-on-surface));
+  line-height: 1.3;
+  padding: 2px 0;
+  resize: none;
+  box-sizing: border-box;
+  overflow: hidden;
 }
 
 .title-input:focus {
-    outline: 2px solid rgb(var(--v-theme-primary));
-    outline-offset: 2px;
-    border-radius: 4px;
+  outline: 2px solid rgb(var(--v-theme-primary));
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
 /* Section label */
 .section-label {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: rgba(var(--v-theme-on-surface), 0.45);
-    margin-bottom: 8px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(var(--v-theme-on-surface), 0.45);
+  margin-bottom: 8px;
 }
 
 /* Description textarea */
 .desc-textarea {
-    width: 100%;
-    min-height: 80px;
-    padding: 0;
-    border: none;
-    background: transparent;
-    color: rgb(var(--v-theme-on-surface));
-    font-size: 0.9rem;
-    font-family: inherit;
-    line-height: 1.6;
-    resize: none;
-    outline: none;
+  width: 100%;
+  min-height: 80px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: rgb(var(--v-theme-on-surface));
+  font-size: 0.9rem;
+  font-family: inherit;
+  line-height: 1.6;
+  resize: none;
+  outline: none;
 }
 
 .desc-textarea::placeholder {
-    color: rgba(var(--v-theme-on-surface), 0.35);
+  color: rgba(var(--v-theme-on-surface), 0.35);
 }
 
 /* Subtasks header */
 .subtasks-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
 }
 
 .subtasks-header__left {
-    display: flex;
-    align-items: center;
-    gap: 7px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
 }
 
 .subtasks-badge {
-    font-size: 0.6875rem;
-    font-weight: 600;
-    background: rgb(var(--v-theme-primary-container));
-    color: rgb(var(--v-theme-on-primary-container));
-    padding: 1px 7px;
-    border-radius: 8px;
-    transition: background 0.2s, color 0.2s;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  background: rgb(var(--v-theme-primary-container));
+  color: rgb(var(--v-theme-on-primary-container));
+  padding: 1px 7px;
+  border-radius: 8px;
+  transition: background 0.2s, color 0.2s;
 }
 
 .subtasks-badge--done {
-    background: rgba(26, 122, 74, 0.12);
-    color: #1a7a4a;
+  background: rgba(26, 122, 74, 0.12);
+  color: #1a7a4a;
 }
 
 .subtasks-progress {
-    width: 64px;
-    height: 3px;
-    border-radius: 2px;
-    background: rgba(var(--v-border-color), 0.2);
-    overflow: hidden;
+  width: 64px;
+  height: 3px;
+  border-radius: 2px;
+  background: rgba(var(--v-border-color), 0.2);
+  overflow: hidden;
 }
 
 .subtasks-progress__bar {
-    height: 100%;
-    border-radius: 2px;
-    background: rgb(var(--v-theme-primary));
-    transition: width 0.3s ease, background 0.3s;
+  height: 100%;
+  border-radius: 2px;
+  background: rgb(var(--v-theme-primary));
+  transition: width 0.3s ease, background 0.3s;
 }
 
 .subtasks-progress__bar--done {
-    background: #1a7a4a;
+  background: #1a7a4a;
 }
 
 /* RIGHT sidebar */
 .todo-sidebar {
-    position: sticky;
-    top: 16px;
+  position: sticky;
+  top: 16px;
 }
 
 .sidebar-card {
-    background: #fff;
-    border-radius: 8px;
-    box-shadow: 0 8px 32px rgba(42, 52, 57, 0.06);
-    padding: 16px;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(42, 52, 57, 0.06);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 /* Property rows */
 .prop-row {
-    display: flex;
-    align-items: center;
-    min-height: 32px;
+  display: flex;
+  align-items: center;
+  min-height: 32px;
 }
 
 .prop-row__label {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    width: 80px;
-    flex-shrink: 0;
-    font-size: 0.8125rem;
-    font-weight: 500;
-    color: rgba(var(--v-theme-on-surface), 0.5);
-    user-select: none;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  width: 80px;
+  flex-shrink: 0;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: rgba(var(--v-theme-on-surface), 0.5);
+  user-select: none;
 }
 
 .prop-row__icon {
-    font-size: 14px;
-    width: 16px;
-    text-align: center;
-    opacity: 0.6;
+  font-size: 14px;
+  width: 16px;
+  text-align: center;
+  opacity: 0.6;
 }
 
 .prop-row__value {
-    flex: 1;
-    font-size: 0.875rem;
-    min-width: 0;
+  flex: 1;
+  font-size: 0.875rem;
+  min-width: 0;
 }
 
 .prop-row__value--plain {
-    color: rgb(var(--v-theme-on-surface));
-    font-size: 0.875rem;
+  color: rgb(var(--v-theme-on-surface));
+  font-size: 0.875rem;
 }
 
 .prop-row__value--overdue :deep(*) {
-    color: #ba1b24 !important;
-    font-weight: 500;
+  color: #ba1b24 !important;
+  font-weight: 500;
 }
 
 /* Status pill */
 .status-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    padding: 3px 10px 3px 7px;
-    border-radius: 20px;
-    border: 1px solid transparent;
-    cursor: pointer;
-    font-size: 0.8125rem;
-    font-weight: 500;
-    font-family: inherit;
-    transition: opacity 0.15s;
-    white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px 3px 7px;
+  border-radius: 20px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  font-family: inherit;
+  transition: opacity 0.15s;
+  white-space: nowrap;
 }
 
 .status-pill:hover {
-    opacity: 0.8;
+  opacity: 0.8;
 }
 
 .status-pill__dot {
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    flex-shrink: 0;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 .status-pill__chevron {
-    font-size: 12px;
-    opacity: 0.7;
+  font-size: 12px;
+  opacity: 0.7;
 }
 
 .pop-menu {
-    list-style: none;
-    margin: 0;
-    padding: 4px;
-    min-width: 140px;
-    background: rgb(var(--v-theme-surface));
-    border: 1px solid rgba(var(--v-border-color), 0.12);
-    border-radius: 8px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  min-width: 140px;
+  background: rgb(var(--v-theme-surface));
+  border: 1px solid rgba(var(--v-border-color), 0.12);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
 }
 
 .pop-menu__item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 7px 10px;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.875rem;
-    transition: background 0.1s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  transition: background 0.1s;
 }
 
 .pop-menu__item:hover {
-    background: rgba(var(--v-border-color), 0.08);
+  background: rgba(var(--v-border-color), 0.08);
 }
 
 .pop-menu__dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 /* Sidebar divider and delete */
 .sidebar-divider {
-    height: 1px;
-    background: rgba(var(--v-border-color), 0.14);
-    margin: 8px 0;
+  height: 1px;
+  background: rgba(var(--v-border-color), 0.14);
+  margin: 8px 0;
 }
 
 .sidebar-delete {
-    display: flex;
-    justify-content: flex-start;
+  display: flex;
+  justify-content: flex-start;
 }
 
 .delete-btn {
-    padding-left: 0 !important;
-    font-size: 0.8125rem;
+  padding-left: 0 !important;
+  font-size: 0.8125rem;
 }
 </style>

--- a/app/components/Todo/Detail.vue
+++ b/app/components/Todo/Detail.vue
@@ -51,7 +51,7 @@ async function deleteTodo() {
   <!-- Two-column layout wrapper -->
   <v-row no-gutters>
     <!-- LEFT: main content -->
-    <v-col cols="12" md="8" class="todo-main">
+    <v-col cols="12" md="8" class="todo-main flex-grow-1">
       <!-- Title -->
       <div class="main-section main-section--title">
         <textarea v-model="listsStore.currentTodo.name" class="title-input" data-testid="todo-detail-title" rows="1"
@@ -83,8 +83,8 @@ async function deleteTodo() {
       </div>
     </v-col>
 
-    <v-col class="todo-sidebar">
-      <v-card width="100%" min-width="350" class="sidebar-card">
+    <v-col cols="auto" class="todo-sidebar flex-grow-1">
+      <v-card width=" 100%" min-width="350" class="sidebar-card">
         <div class="prop-row">
           <div class="prop-row__label">
             <i class="mdi mdi-circle-slice-4 prop-row__icon" />
@@ -297,6 +297,15 @@ async function deleteTodo() {
   top: 16px;
 }
 
+.sidebar-card {
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(42, 52, 57, 0.06);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
 
 /* Property rows */
 .prop-row {

--- a/app/components/Todo/Detail.vue
+++ b/app/components/Todo/Detail.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 const listsStore = useListsStore();
 const { statuses } = useSettingsStore();
+const router = useRouter();
 const hasGithub = await useHasGithub();
 
 function updateName() {
@@ -41,189 +42,255 @@ const subtaskPct = computed(() =>
     subtaskTotal.value ? Math.round((subtaskDone.value / subtaskTotal.value) * 100) : 0,
 );
 const allDone = computed(() => subtaskTotal.value > 0 && subtaskPct.value === 100);
+
+async function deleteTodo() {
+    if (!listsStore.currentTodo?.id) return;
+    const listId = listsStore.currentTodo.listId;
+    await listsStore.deleteTodo(listsStore.currentTodo.id);
+    if (listId) {
+        router.push(`/list/${listId}`);
+    } else {
+        router.push('/');
+    }
+}
 </script>
 
 <template>
     <div class="todo-detail">
-        <!-- Title -->
-        <div class="detail-section detail-section--title">
-            <textarea
-                v-model="listsStore.currentTodo.name"
-                class="title-input"
-                data-testid="todo-detail-title"
-                rows="1"
-                @blur="updateName"
-            />
-        </div>
-
-        <!-- Properties -->
-        <div class="detail-section detail-section--props">
-            <!-- Status -->
-            <div class="prop-row">
-                <div class="prop-row__label">
-                    <i class="mdi mdi-circle-slice-4 prop-row__icon" />
-                    <span>Status</span>
-                </div>
-                <div class="prop-row__value">
-                    <v-menu>
-                        <template #activator="{ props }">
-                            <button
-                                v-bind="props"
-                                class="status-pill"
-                                :style="{
-                                    background: `${currentStatus.color}18`,
-                                    color: currentStatus.color,
-                                    borderColor: `${currentStatus.color}33`,
-                                }"
-                            >
-                                <span
-                                    class="status-pill__dot"
-                                    :style="{ background: currentStatus.color }"
-                                />
-                                {{ listsStore.currentTodo.status }}
-                                <i class="mdi mdi-chevron-down status-pill__chevron" />
-                            </button>
-                        </template>
-                        <ul class="pop-menu">
-                            <li
-                                v-for="s in statuses"
-                                :key="s.name"
-                                class="pop-menu__item"
-                                @click="setStatus(s)"
-                            >
-                                <span
-                                    class="pop-menu__dot"
-                                    :style="{ background: s.color }"
-                                />
-                                {{ s.name }}
-                            </li>
-                        </ul>
-                    </v-menu>
-                </div>
-            </div>
-
-            <!-- Due date -->
-            <div class="prop-row">
-                <div class="prop-row__label">
-                    <i class="mdi mdi-calendar prop-row__icon" />
-                    <span>Due date</span>
-                </div>
-                <div class="prop-row__value">
-                    <AppDueDate
-                        :todo="listsStore.currentTodo"
-                        :todo-due-date="listsStore.currentTodo.dueDate"
-                        :show-detail="true"
-                        :class="{ 'due-date--overdue': isOverdue }"
-                        @set-date="updateDueDate"
+        <!-- Two-column layout wrapper -->
+        <div class="todo-layout">
+            <!-- LEFT: main content -->
+            <div class="todo-main">
+                <!-- Title -->
+                <div class="main-section main-section--title">
+                    <textarea
+                        v-model="listsStore.currentTodo.name"
+                        class="title-input"
+                        data-testid="todo-detail-title"
+                        rows="1"
+                        @blur="updateName"
                     />
                 </div>
-            </div>
 
-            <!-- List -->
-            <div class="prop-row">
-                <div class="prop-row__label">
-                    <i class="mdi mdi-format-list-bulleted prop-row__icon" />
-                    <span>List</span>
-                </div>
-                <div class="prop-row__value prop-row__value--plain">
-                    {{ listsStore.currentList?.name }}
-                </div>
-            </div>
-
-            <!-- GitHub (conditional) -->
-            <div
-                v-if="hasGithub"
-                class="prop-row"
-            >
-                <div class="prop-row__label">
-                    <i class="mdi mdi-github prop-row__icon" />
-                    <span>GitHub</span>
-                </div>
-                <div class="prop-row__value">
-                    <GithubButton :todo="listsStore.currentTodo" />
-                </div>
-            </div>
-        </div>
-
-        <!-- Description -->
-        <div class="detail-section">
-            <div class="section-label">
-                Description
-            </div>
-            <textarea
-                v-model="listsStore.currentTodo.desc"
-                class="desc-textarea"
-                placeholder="Add a description…"
-                @input="listsStore.debounceUpdateTodo(listsStore.currentTodo)"
-                @blur="listsStore.updateTodo(listsStore.currentTodo)"
-            />
-        </div>
-
-        <div class="divider" />
-
-        <!-- Subtasks -->
-        <div class="detail-section">
-            <div class="subtasks-header">
-                <div class="subtasks-header__left">
-                    <span class="section-label">Subtasks</span>
-                    <span
-                        v-if="subtaskTotal"
-                        class="subtasks-badge"
-                        :class="{ 'subtasks-badge--done': allDone }"
-                    >
-                        {{ subtaskDone }}/{{ subtaskTotal }}
-                    </span>
-                </div>
-                <div
-                    v-if="subtaskTotal"
-                    class="subtasks-progress"
-                >
-                    <div
-                        class="subtasks-progress__bar"
-                        :class="{ 'subtasks-progress__bar--done': allDone }"
-                        :style="{ width: subtaskPct + '%' }"
+                <!-- Description -->
+                <div class="main-section">
+                    <div class="section-label">
+                        Description
+                    </div>
+                    <textarea
+                        v-model="listsStore.currentTodo.desc"
+                        class="desc-textarea"
+                        placeholder="Add a description…"
+                        @input="listsStore.debounceUpdateTodo(listsStore.currentTodo)"
+                        @blur="listsStore.updateTodo(listsStore.currentTodo)"
                     />
                 </div>
-            </div>
-            <Subtask />
-        </div>
 
-        <div class="divider" />
+                <div class="divider" />
 
-        <!-- Links -->
-        <div class="detail-section">
-            <div class="section-label">
-                Links
+                <!-- Subtasks -->
+                <div class="main-section">
+                    <div class="subtasks-header">
+                        <div class="subtasks-header__left">
+                            <span class="section-label">Subtasks</span>
+                            <span
+                                v-if="subtaskTotal"
+                                class="subtasks-badge"
+                                :class="{ 'subtasks-badge--done': allDone }"
+                            >
+                                {{ subtaskDone }}/{{ subtaskTotal }}
+                            </span>
+                        </div>
+                        <div v-if="subtaskTotal" class="subtasks-progress">
+                            <div
+                                class="subtasks-progress__bar"
+                                :class="{ 'subtasks-progress__bar--done': allDone }"
+                                :style="{ width: subtaskPct + '%' }"
+                            />
+                        </div>
+                    </div>
+                    <Subtask />
+                </div>
+
+                <div class="divider" />
+
+                <!-- Links -->
+                <div class="main-section">
+                    <div class="section-label">
+                        Links
+                    </div>
+                    <TodoLinks />
+                </div>
             </div>
-            <TodoLinks />
+
+            <!-- RIGHT: sidebar -->
+            <aside class="todo-sidebar">
+                <div class="sidebar-card">
+                    <!-- Status -->
+                    <div class="prop-row">
+                        <div class="prop-row__label">
+                            <i class="mdi mdi-circle-slice-4 prop-row__icon" />
+                            <span>Status</span>
+                        </div>
+                        <div class="prop-row__value">
+                            <v-menu>
+                                <template #activator="{ props }">
+                                    <button
+                                        v-bind="props"
+                                        class="status-pill"
+                                        :style="{
+                                            background: `${currentStatus.color}18`,
+                                            color: currentStatus.color,
+                                            borderColor: `${currentStatus.color}33`,
+                                        }"
+                                    >
+                                        <span
+                                            class="status-pill__dot"
+                                            :style="{ background: currentStatus.color }"
+                                        />
+                                        {{ listsStore.currentTodo.status }}
+                                        <i class="mdi mdi-chevron-down status-pill__chevron" />
+                                    </button>
+                                </template>
+                                <ul class="pop-menu">
+                                    <li
+                                        v-for="s in statuses"
+                                        :key="s.name"
+                                        class="pop-menu__item"
+                                        @click="setStatus(s)"
+                                    >
+                                        <span
+                                            class="pop-menu__dot"
+                                            :style="{ background: s.color }"
+                                        />
+                                        {{ s.name }}
+                                    </li>
+                                </ul>
+                            </v-menu>
+                        </div>
+                    </div>
+
+                    <!-- Due date -->
+                    <div class="prop-row">
+                        <div class="prop-row__label">
+                            <i class="mdi mdi-calendar prop-row__icon" />
+                            <span>Due date</span>
+                        </div>
+                        <div class="prop-row__value" :class="{ 'prop-row__value--overdue': isOverdue }">
+                            <AppDueDate
+                                :todo="listsStore.currentTodo"
+                                :todo-due-date="listsStore.currentTodo.dueDate"
+                                :show-detail="true"
+                                @set-date="updateDueDate"
+                            />
+                        </div>
+                    </div>
+
+                    <!-- List -->
+                    <div class="prop-row">
+                        <div class="prop-row__label">
+                            <i class="mdi mdi-format-list-bulleted prop-row__icon" />
+                            <span>List</span>
+                        </div>
+                        <div class="prop-row__value prop-row__value--plain">
+                            {{ listsStore.currentList?.name }}
+                        </div>
+                    </div>
+
+                    <!-- GitHub (conditional) -->
+                    <div v-if="hasGithub" class="prop-row">
+                        <div class="prop-row__label">
+                            <i class="mdi mdi-github prop-row__icon" />
+                            <span>GitHub</span>
+                        </div>
+                        <div class="prop-row__value">
+                            <GithubButton :todo="listsStore.currentTodo" />
+                        </div>
+                    </div>
+
+                    <div class="sidebar-divider" />
+
+                    <!-- Delete -->
+                    <div class="sidebar-delete">
+                        <v-dialog width="260px">
+                            <template #activator="{ props: activatorProps }">
+                                <v-btn
+                                    v-bind="activatorProps"
+                                    color="error"
+                                    variant="text"
+                                    prepend-icon="mdi-trash-can-outline"
+                                    size="small"
+                                    class="delete-btn"
+                                >
+                                    Delete todo
+                                </v-btn>
+                            </template>
+                            <template #default="{ isActive }">
+                                <v-card rounded="lg">
+                                    <v-card-text>
+                                        Are you sure you want to delete this todo?
+                                    </v-card-text>
+                                    <v-card-actions>
+                                        <v-spacer />
+                                        <v-btn color="error" @click="deleteTodo">
+                                            Delete
+                                        </v-btn>
+                                        <v-btn @click="isActive.value = false">
+                                            Cancel
+                                        </v-btn>
+                                    </v-card-actions>
+                                </v-card>
+                            </template>
+                        </v-dialog>
+                    </div>
+                </div>
+            </aside>
         </div>
     </div>
 </template>
 
 <style scoped>
 .todo-detail {
-    display: flex;
-    flex-direction: column;
     width: 100%;
     padding-bottom: 40px;
 }
 
-.detail-section {
+/* Two-column grid: left fluid, right fixed 248px */
+.todo-layout {
+    display: grid;
+    grid-template-columns: 1fr 248px;
+    gap: 20px;
+    align-items: start;
+}
+
+/* Stack vertically on mobile */
+@media (max-width: 959px) {
+    .todo-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .todo-sidebar {
+        order: -1;
+    }
+}
+
+/* LEFT column */
+.todo-main {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 8px 32px rgba(42, 52, 57, 0.06);
+    padding-bottom: 8px;
+}
+
+.main-section {
     padding: 12px 20px;
 }
 
-.detail-section--title {
+.main-section--title {
     padding: 18px 20px 10px;
-}
-
-.detail-section--props {
-    padding: 8px 20px 12px;
-    background: rgb(var(--v-theme-surface-container-low));
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    margin: 0 12px;
-    border-radius: 10px;
 }
 
 .divider {
@@ -239,7 +306,7 @@ const allDone = computed(() => subtaskTotal.value > 0 && subtaskPct.value === 10
     border: none;
     outline: none;
     font-family: 'Manrope', sans-serif;
-    font-size: 1.1875rem;
+    font-size: 1.3125rem;
     font-weight: 700;
     color: rgb(var(--v-theme-on-surface));
     line-height: 1.3;
@@ -253,112 +320,6 @@ const allDone = computed(() => subtaskTotal.value > 0 && subtaskPct.value === 10
     outline: 2px solid rgb(var(--v-theme-primary));
     outline-offset: 2px;
     border-radius: 4px;
-}
-
-/* Property rows */
-.prop-row {
-    display: flex;
-    align-items: center;
-    min-height: 32px;
-}
-
-.prop-row__label {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    width: 108px;
-    flex-shrink: 0;
-    font-size: 0.8125rem;
-    font-weight: 500;
-    color: rgba(var(--v-theme-on-surface), 0.5);
-    user-select: none;
-}
-
-.prop-row__icon {
-    font-size: 14px;
-    width: 16px;
-    text-align: center;
-    opacity: 0.6;
-}
-
-.prop-row__value {
-    flex: 1;
-    font-size: 0.875rem;
-}
-
-.prop-row__value--plain {
-    color: rgb(var(--v-theme-on-surface));
-    font-size: 0.875rem;
-}
-
-/* Status pill */
-.status-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 5px;
-    padding: 3px 10px 3px 7px;
-    border-radius: 20px;
-    border: 1px solid transparent;
-    cursor: pointer;
-    font-size: 0.8125rem;
-    font-weight: 500;
-    font-family: inherit;
-    transition: opacity 0.15s;
-}
-
-.status-pill:hover {
-    opacity: 0.8;
-}
-
-.status-pill__dot {
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    flex-shrink: 0;
-}
-
-.status-pill__chevron {
-    font-size: 12px;
-    opacity: 0.7;
-}
-
-.pop-menu {
-    list-style: none;
-    margin: 0;
-    padding: 4px;
-    min-width: 140px;
-    background: rgb(var(--v-theme-surface));
-    border: 1px solid rgba(var(--v-border-color), 0.12);
-    border-radius: 8px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
-}
-
-.pop-menu__item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 7px 10px;
-    border-radius: 6px;
-    cursor: pointer;
-    font-size: 0.875rem;
-    transition: background 0.1s;
-}
-
-.pop-menu__item:hover {
-    background: rgba(var(--v-border-color), 0.08);
-}
-
-.pop-menu__dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
-}
-
-/* Due date overdue */
-:deep(.due-date--overdue .date-field__input) {
-    color: rgb(var(--v-theme-tertiary));
-    font-weight: 500;
 }
 
 /* Section label */
@@ -411,9 +372,7 @@ const allDone = computed(() => subtaskTotal.value > 0 && subtaskPct.value === 10
     color: rgb(var(--v-theme-on-primary-container));
     padding: 1px 7px;
     border-radius: 8px;
-    transition:
-        background 0.2s,
-        color 0.2s;
+    transition: background 0.2s, color 0.2s;
 }
 
 .subtasks-badge--done {
@@ -433,12 +392,150 @@ const allDone = computed(() => subtaskTotal.value > 0 && subtaskPct.value === 10
     height: 100%;
     border-radius: 2px;
     background: rgb(var(--v-theme-primary));
-    transition:
-        width 0.3s ease,
-        background 0.3s;
+    transition: width 0.3s ease, background 0.3s;
 }
 
 .subtasks-progress__bar--done {
     background: #1a7a4a;
+}
+
+/* RIGHT sidebar */
+.todo-sidebar {
+    position: sticky;
+    top: 16px;
+}
+
+.sidebar-card {
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 8px 32px rgba(42, 52, 57, 0.06);
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+/* Property rows */
+.prop-row {
+    display: flex;
+    align-items: center;
+    min-height: 32px;
+}
+
+.prop-row__label {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    width: 80px;
+    flex-shrink: 0;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: rgba(var(--v-theme-on-surface), 0.5);
+    user-select: none;
+}
+
+.prop-row__icon {
+    font-size: 14px;
+    width: 16px;
+    text-align: center;
+    opacity: 0.6;
+}
+
+.prop-row__value {
+    flex: 1;
+    font-size: 0.875rem;
+    min-width: 0;
+}
+
+.prop-row__value--plain {
+    color: rgb(var(--v-theme-on-surface));
+    font-size: 0.875rem;
+}
+
+.prop-row__value--overdue :deep(*) {
+    color: #ba1b24 !important;
+    font-weight: 500;
+}
+
+/* Status pill */
+.status-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 3px 10px 3px 7px;
+    border-radius: 20px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    font-family: inherit;
+    transition: opacity 0.15s;
+    white-space: nowrap;
+}
+
+.status-pill:hover {
+    opacity: 0.8;
+}
+
+.status-pill__dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.status-pill__chevron {
+    font-size: 12px;
+    opacity: 0.7;
+}
+
+.pop-menu {
+    list-style: none;
+    margin: 0;
+    padding: 4px;
+    min-width: 140px;
+    background: rgb(var(--v-theme-surface));
+    border: 1px solid rgba(var(--v-border-color), 0.12);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+}
+
+.pop-menu__item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 7px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    transition: background 0.1s;
+}
+
+.pop-menu__item:hover {
+    background: rgba(var(--v-border-color), 0.08);
+}
+
+.pop-menu__dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+/* Sidebar divider and delete */
+.sidebar-divider {
+    height: 1px;
+    background: rgba(var(--v-border-color), 0.14);
+    margin: 8px 0;
+}
+
+.sidebar-delete {
+    display: flex;
+    justify-content: flex-start;
+}
+
+.delete-btn {
+    padding-left: 0 !important;
+    font-size: 0.8125rem;
 }
 </style>

--- a/app/components/Todo/Detail.vue
+++ b/app/components/Todo/Detail.vue
@@ -48,172 +48,135 @@ async function deleteTodo() {
 </script>
 
 <template>
-  <div class="todo-detail">
-    <!-- Two-column layout wrapper -->
-    <div class="todo-layout">
-      <!-- LEFT: main content -->
-      <div class="todo-main">
-        <!-- Title -->
-        <div class="main-section main-section--title">
-          <textarea v-model="listsStore.currentTodo.name" class="title-input" data-testid="todo-detail-title" rows="1"
-            @blur="updateName" />
-        </div>
-
-        <!-- Description -->
-        <div class="main-section">
-          <div class="section-label">
-            Description
-          </div>
-          <textarea v-model="listsStore.currentTodo.desc" class="desc-textarea" placeholder="Add a description…"
-            @input="listsStore.debounceUpdateTodo(listsStore.currentTodo)"
-            @blur="listsStore.updateTodo(listsStore.currentTodo)" />
-        </div>
-
-        <div class="divider" />
-
-        <Subtasks />
-
-        <div class="divider" />
-
-        <!-- Links -->
-        <div class="main-section">
-          <div class="section-label">
-            Links
-          </div>
-          <TodoLinks />
-        </div>
+  <!-- Two-column layout wrapper -->
+  <v-row no-gutters>
+    <!-- LEFT: main content -->
+    <v-col cols="12" md="8" class="todo-main">
+      <!-- Title -->
+      <div class="main-section main-section--title">
+        <textarea v-model="listsStore.currentTodo.name" class="title-input" data-testid="todo-detail-title" rows="1"
+          @blur="updateName" />
       </div>
 
-      <aside class="todo-sidebar">
-        <div class="sidebar-card">
-          <div class="prop-row">
-            <div class="prop-row__label">
-              <i class="mdi mdi-circle-slice-4 prop-row__icon" />
-              <span>Status</span>
-            </div>
-            <div class="prop-row__value">
-              <v-menu>
-                <template #activator="{ props }">
-                  <button v-bind="props" class="status-pill" :style="{
-                    background: `${currentStatus.color}18`,
-                    color: currentStatus.color,
-                    borderColor: `${currentStatus.color}33`,
-                  }">
-                    <span class="status-pill__dot" :style="{ background: currentStatus.color }" />
-                    {{ listsStore.currentTodo.status }}
-                    <i class="mdi mdi-chevron-down status-pill__chevron" />
-                  </button>
-                </template>
-                <ul class="pop-menu">
-                  <li v-for="s in statuses" :key="s.name" class="pop-menu__item" @click="setStatus(s)">
-                    <span class="pop-menu__dot" :style="{ background: s.color }" />
-                    {{ s.name }}
-                  </li>
-                </ul>
-              </v-menu>
-            </div>
-          </div>
+      <!-- Description -->
+      <div class="main-section">
+        <div class="section-label">
+          Description
+        </div>
+        <textarea v-model="listsStore.currentTodo.desc" class="desc-textarea" placeholder="Add a description…"
+          @input="listsStore.debounceUpdateTodo(listsStore.currentTodo)"
+          @blur="listsStore.updateTodo(listsStore.currentTodo)" />
+      </div>
 
-          <div class="prop-row">
-            <div class="prop-row__label">
-              <i class="mdi mdi-calendar prop-row__icon" />
-              <span>Due date</span>
-            </div>
-            <div class="prop-row__value" :class="{ 'prop-row__value--overdue': isOverdue }">
-              <AppDueDate :todo="listsStore.currentTodo" :todo-due-date="listsStore.currentTodo.dueDate"
-                :show-detail="true" @set-date="updateDueDate" />
-            </div>
-          </div>
-          <div class="prop-row">
-            <div class="prop-row__label">
-              <i class="mdi mdi-format-list-bulleted prop-row__icon" />
-              <span>List</span>
-            </div>
-            <div class="prop-row__value prop-row__value--plain">
-              {{ listsStore.currentList?.name }}
-            </div>
-          </div>
+      <div class="divider" />
 
-          <div v-if="hasGithub" class="prop-row">
-            <div class="prop-row__label">
-              <i class="mdi mdi-github prop-row__icon" />
-              <span>GitHub</span>
-            </div>
-            <div class="prop-row__value">
-              <GithubButton :todo="listsStore.currentTodo" />
-            </div>
+      <Subtasks />
+
+      <div class="divider" />
+
+      <!-- Links -->
+      <div class="main-section">
+        <div class="section-label">
+          Links
+        </div>
+        <TodoLinks />
+      </div>
+    </v-col>
+
+    <v-col class="todo-sidebar">
+      <v-card width="100%" min-width="350" class="sidebar-card">
+        <div class="prop-row">
+          <div class="prop-row__label">
+            <i class="mdi mdi-circle-slice-4 prop-row__icon" />
+            <span>Status</span>
           </div>
-
-          <div class="sidebar-divider" />
-
-          <div class="sidebar-delete">
-            <v-dialog width="260px">
-              <template #activator="{ props: activatorProps }">
-                <v-btn v-bind="activatorProps" color="error" variant="text" prepend-icon="mdi-trash-can-outline"
-                  size="small" class="delete-btn">
-                  Delete todo
-                </v-btn>
+          <div class="prop-row__value">
+            <v-menu>
+              <template #activator="{ props }">
+                <button v-bind="props" class="status-pill" :style="{
+                  background: `${currentStatus.color}18`,
+                  color: currentStatus.color,
+                  borderColor: `${currentStatus.color}33`,
+                }">
+                  <span class="status-pill__dot" :style="{ background: currentStatus.color }" />
+                  {{ listsStore.currentTodo.status }}
+                  <i class="mdi mdi-chevron-down status-pill__chevron" />
+                </button>
               </template>
-              <template #default="{ isActive }">
-                <v-card rounded="lg">
-                  <v-card-text>
-                    Are you sure you want to delete this todo?
-                  </v-card-text>
-                  <v-card-actions>
-                    <v-spacer />
-                    <v-btn color="error" @click="deleteTodo">
-                      Delete
-                    </v-btn>
-                    <v-btn @click="isActive.value = false">
-                      Cancel
-                    </v-btn>
-                  </v-card-actions>
-                </v-card>
-              </template>
-            </v-dialog>
+              <ul class="pop-menu">
+                <li v-for="s in statuses" :key="s.name" class="pop-menu__item" @click="setStatus(s)">
+                  <span class="pop-menu__dot" :style="{ background: s.color }" />
+                  {{ s.name }}
+                </li>
+              </ul>
+            </v-menu>
           </div>
         </div>
-      </aside>
-    </div>
-  </div>
+
+        <div class="prop-row">
+          <div class="prop-row__label">
+            <i class="mdi mdi-calendar prop-row__icon" />
+            <span>Due date</span>
+          </div>
+          <div class="prop-row__value" :class="{ 'prop-row__value--overdue': isOverdue }">
+            <AppDueDate :todo="listsStore.currentTodo" :todo-due-date="listsStore.currentTodo.dueDate"
+              :show-detail="true" @set-date="updateDueDate" />
+          </div>
+        </div>
+        <div class="prop-row">
+          <div class="prop-row__label">
+            <i class="mdi mdi-format-list-bulleted prop-row__icon" />
+            <span>List</span>
+          </div>
+          <div class="prop-row__value prop-row__value--plain">
+            {{ listsStore.currentList?.name }}
+          </div>
+        </div>
+
+        <div v-if="hasGithub" class="prop-row">
+          <div class="prop-row__label">
+            <i class="mdi mdi-github prop-row__icon" />
+            <span>GitHub</span>
+          </div>
+          <div class="prop-row__value">
+            <GithubButton :todo="listsStore.currentTodo" />
+          </div>
+        </div>
+
+        <div class="sidebar-divider" />
+
+        <div class="sidebar-delete">
+          <v-dialog width="260px">
+            <template #activator="{ props: activatorProps }">
+              <v-btn v-bind="activatorProps" color="error" variant="text" prepend-icon="mdi-trash-can-outline"
+                size="small" class="delete-btn">
+              </v-btn>
+            </template>
+            <template #default="{ isActive }">
+              <v-card rounded="lg">
+                <v-card-text>
+                  Are you sure you want to delete this todo?
+                </v-card-text>
+                <v-card-actions>
+                  <v-spacer />
+                  <v-btn color="error" @click="deleteTodo">
+                    Delete
+                  </v-btn>
+                  <v-btn @click="isActive.value = false">
+                    Cancel
+                  </v-btn>
+                </v-card-actions>
+              </v-card>
+            </template>
+          </v-dialog>
+        </div>
+      </v-card>
+    </v-col>
+  </v-row>
+
 </template>
 
 <style scoped>
-.todo-detail {
-  width: 100%;
-  padding-bottom: 40px;
-}
-
-/* Two-column grid: left fluid, right fixed 248px */
-.todo-layout {
-  display: grid;
-  grid-template-columns: 1fr 248px;
-  gap: 20px;
-  align-items: start;
-}
-
-/* Stack vertically on mobile */
-@media (max-width: 959px) {
-  .todo-layout {
-    grid-template-columns: 1fr;
-  }
-
-  .todo-sidebar {
-    order: -1;
-  }
-}
-
-/* LEFT column */
-.todo-main {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 8px 32px rgba(42, 52, 57, 0.06);
-  padding-bottom: 8px;
-}
-
 .main-section {
   padding: 12px 20px;
 }
@@ -334,15 +297,6 @@ async function deleteTodo() {
   top: 16px;
 }
 
-.sidebar-card {
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 8px 32px rgba(42, 52, 57, 0.06);
-  padding: 16px;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
 
 /* Property rows */
 .prop-row {

--- a/app/components/Todo/Detail.vue
+++ b/app/components/Todo/Detail.vue
@@ -3,6 +3,7 @@ const listsStore = useListsStore();
 const { statuses } = useSettingsStore();
 const router = useRouter();
 const hasGithub = await useHasGithub();
+const { mainWidth } = defineProps<{ mainWidth?: string }>()
 
 function updateName() {
   if (listsStore.currentTodo.name) {
@@ -48,10 +49,8 @@ async function deleteTodo() {
 </script>
 
 <template>
-  <!-- Two-column layout wrapper -->
   <v-row no-gutters>
-    <!-- LEFT: main content -->
-    <v-col cols="12" md="8" class="todo-main flex-grow-1">
+    <v-col cols="12" :md="mainWidth ? mainWidth : 8" class="todo-main flex-grow-1">
       <!-- Title -->
       <div class="main-section main-section--title">
         <textarea v-model="listsStore.currentTodo.name" class="title-input" data-testid="todo-detail-title" rows="1"

--- a/app/components/Todo/Panel.vue
+++ b/app/components/Todo/Panel.vue
@@ -64,7 +64,7 @@ async function confirmDelete() {
     <!-- Panel content -->
     <div class="panel-body">
       <Suspense>
-        <TodoDetail />
+        <TodoDetail main-width="12" />
       </Suspense>
     </div>
   </aside>

--- a/app/components/Todo/Panel.vue
+++ b/app/components/Todo/Panel.vue
@@ -6,214 +6,190 @@ const deleteDialog = ref(false);
 defineEmits(['close']);
 
 function openFullPage() {
-    router.push(`/todo/${listsStore.currentTodo.id}`);
+  router.push(`/todo/${listsStore.currentTodo.id}`);
 }
 
 async function confirmDelete() {
-    await listsStore.deleteTodo(listsStore.currentTodo.id);
-    deleteDialog.value = false;
+  await listsStore.deleteTodo(listsStore.currentTodo.id);
+  deleteDialog.value = false;
 }
 </script>
 
 <template>
-    <aside class="todo-panel">
-        <!-- Panel header -->
-        <div class="panel-header">
-            <div class="panel-header__start">
-                <button
-                    class="icon-btn"
-                    title="Open full page"
-                    aria-label="Open full page"
-                    @click="openFullPage"
-                >
-                    <i class="mdi mdi-arrow-expand" />
-                </button>
+  <aside class="todo-panel">
+    <!-- Panel header -->
+    <div class="panel-header">
+      <div class="panel-header__start">
+        <button class="icon-btn" title="Open full page" aria-label="Open full page" @click="openFullPage">
+          <i class="mdi mdi-arrow-expand" />
+        </button>
+      </div>
+
+      <div class="panel-header__end">
+        <!-- Delete with confirm dialog -->
+        <v-dialog v-model="deleteDialog" max-width="280">
+          <template #activator="{ props }">
+            <button v-bind="props" class="icon-btn icon-btn--danger" title="Delete task" aria-label="Delete task">
+              <i class="mdi mdi-trash-can-outline" />
+            </button>
+          </template>
+          <div class="confirm-dialog">
+            <div class="confirm-dialog__title">
+              Delete task
             </div>
-
-            <div class="panel-header__end">
-                <!-- Delete with confirm dialog -->
-                <v-dialog
-                    v-model="deleteDialog"
-                    max-width="280"
-                >
-                    <template #activator="{ props }">
-                        <button
-                            v-bind="props"
-                            class="icon-btn icon-btn--danger"
-                            title="Delete task"
-                            aria-label="Delete task"
-                        >
-                            <i class="mdi mdi-trash-can-outline" />
-                        </button>
-                    </template>
-                    <div class="confirm-dialog">
-                        <div class="confirm-dialog__title">
-                            Delete task
-                        </div>
-                        <div class="confirm-dialog__desc">
-                            Are you sure you want to delete "{{ listsStore.currentTodo.name }}"?
-                        </div>
-                        <div class="confirm-dialog__actions">
-                            <button
-                                class="btn"
-                                @click="deleteDialog = false"
-                            >
-                                Cancel
-                            </button>
-                            <button
-                                class="btn btn--danger"
-                                @click="
-                                    confirmDelete();
-                                    $emit('close');
-                                "
-                            >
-                                Delete
-                            </button>
-                        </div>
-                    </div>
-                </v-dialog>
-
-                <!-- Close panel -->
-                <button
-                    class="icon-btn"
-                    title="Close panel"
-                    aria-label="Close panel"
-                    @click="$emit('close')"
-                >
-                    <i class="mdi mdi-close" />
-                </button>
+            <div class="confirm-dialog__desc">
+              Are you sure you want to delete "{{ listsStore.currentTodo.name }}"?
             </div>
-        </div>
+            <div class="confirm-dialog__actions">
+              <button class="btn" @click="deleteDialog = false">
+                Cancel
+              </button>
+              <button class="btn btn--danger" @click="
+                confirmDelete();
+              $emit('close');
+              ">
+                Delete
+              </button>
+            </div>
+          </div>
+        </v-dialog>
 
-        <!-- Panel content -->
-        <div class="panel-body">
-            <Suspense>
-                <TodoDetail />
-            </Suspense>
-        </div>
-    </aside>
+        <!-- Close panel -->
+        <button class="icon-btn" title="Close panel" aria-label="Close panel" @click="$emit('close')">
+          <i class="mdi mdi-close" />
+        </button>
+      </div>
+    </div>
+
+    <!-- Panel content -->
+    <div class="panel-body">
+      <Suspense>
+        <TodoDetail />
+      </Suspense>
+    </div>
+  </aside>
 </template>
 
 <style scoped>
 .todo-panel {
-    width: 400px;
-    flex-shrink: 0;
-    display: flex;
-    flex-direction: column;
-    border-left: 1px solid rgba(var(--v-border-color), 0.14);
-    background: rgb(var(--v-theme-surface));
-    height: 100%;
-    overflow: hidden;
+  width: 50%;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid rgba(var(--v-border-color), 0.14);
+  background: rgb(var(--v-theme-surface));
+  height: 100%;
+  overflow: hidden;
 }
 
 .panel-header {
-    height: 44px;
-    border-bottom: 1px solid rgba(var(--v-border-color), 0.14);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 10px;
-    flex-shrink: 0;
+  height: 44px;
+  border-bottom: 1px solid rgba(var(--v-border-color), 0.14);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 10px;
+  flex-shrink: 0;
 }
 
 .panel-header__start,
 .panel-header__end {
-    display: flex;
-    align-items: center;
-    gap: 2px;
+  display: flex;
+  align-items: center;
+  gap: 2px;
 }
 
 .panel-body {
-    flex: 1;
-    overflow-y: auto;
-    scrollbar-width: thin;
-    scrollbar-color: rgba(var(--v-border-color), 0.2) transparent;
+  flex: 1;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--v-border-color), 0.2) transparent;
 }
 
 .icon-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    border-radius: 6px;
-    color: rgba(var(--v-theme-on-surface), 0.5);
-    padding: 0;
-    transition:
-        background 0.1s,
-        color 0.1s;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 6px;
+  color: rgba(var(--v-theme-on-surface), 0.5);
+  padding: 0;
+  transition:
+    background 0.1s,
+    color 0.1s;
 }
 
 .icon-btn:hover {
-    background: rgba(var(--v-border-color), 0.08);
-    color: rgb(var(--v-theme-on-surface));
+  background: rgba(var(--v-border-color), 0.08);
+  color: rgb(var(--v-theme-on-surface));
 }
 
 .icon-btn--danger:hover {
-    background: rgba(var(--v-theme-tertiary), 0.08);
-    color: rgb(var(--v-theme-tertiary));
+  background: rgba(var(--v-theme-tertiary), 0.08);
+  color: rgb(var(--v-theme-tertiary));
 }
 
 .icon-btn .mdi {
-    font-size: 15px;
+  font-size: 15px;
 }
 
 .confirm-dialog {
-    background: rgb(var(--v-theme-surface));
-    color: rgb(var(--v-theme-on-surface));
-    border-radius: 12px;
-    padding: 24px;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.24);
+  background: rgb(var(--v-theme-surface));
+  color: rgb(var(--v-theme-on-surface));
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.24);
 }
 
 .confirm-dialog__title {
-    font-size: 1rem;
-    font-weight: 600;
-    margin: 0 0 8px;
-    display: block;
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 8px;
+  display: block;
 }
 
 .confirm-dialog__desc {
-    font-size: 0.875rem;
-    color: rgba(var(--v-theme-on-surface), 0.65);
-    margin: 0 0 20px;
-    line-height: 1.5;
-    display: block;
+  font-size: 0.875rem;
+  color: rgba(var(--v-theme-on-surface), 0.65);
+  margin: 0 0 20px;
+  line-height: 1.5;
+  display: block;
 }
 
 .confirm-dialog__actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 6px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
 }
 
 .btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 6px 16px;
-    border: none;
-    background: transparent;
-    cursor: pointer;
-    border-radius: 8px;
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: inherit;
-    font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 16px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: inherit;
+  font-family: inherit;
 }
 
 .btn:hover {
-    background: rgba(var(--v-border-color), 0.08);
+  background: rgba(var(--v-border-color), 0.08);
 }
 
 .btn--danger {
-    color: rgb(var(--v-theme-tertiary));
+  color: rgb(var(--v-theme-tertiary));
 }
 
 .btn--danger:hover {
-    background: rgba(var(--v-theme-tertiary), 0.08);
+  background: rgba(var(--v-theme-tertiary), 0.08);
 }
 </style>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -3,25 +3,18 @@ const colorMode = useColorMode();
 </script>
 
 <template>
-    <ColorScheme>
-        <v-theme-provider
-            with-background
-            :theme="colorMode.preference"
-            class="overflow-auto"
-        >
-            <v-app full-height>
-                <AppToolbar />
-                <AppNav />
-                <v-main>
-                    <v-container
-                        fluid
-                        class="pa-0 fill-height"
-                    >
-                        <AppSettings />
-                        <NuxtPage />
-                    </v-container>
-                </v-main>
-            </v-app>
-        </v-theme-provider>
-    </ColorScheme>
+  <ColorScheme>
+    <v-theme-provider with-background :theme="colorMode.preference" class="overflow-auto">
+      <v-app full-height>
+        <AppToolbar />
+        <AppNav />
+        <v-main>
+          <v-container fluid class="pa-0 fill-height">
+            <AppSettings />
+            <NuxtPage />
+          </v-container>
+        </v-main>
+      </v-app>
+    </v-theme-provider>
+  </ColorScheme>
 </template>

--- a/app/layouts/mobile.vue
+++ b/app/layouts/mobile.vue
@@ -4,10 +4,16 @@ const colorMode = useColorMode();
 
 <template>
     <ColorScheme>
-        <v-theme-provider with-background :theme="colorMode.preference">
+        <v-theme-provider
+            with-background
+            :theme="colorMode.preference"
+        >
             <v-app>
                 <v-main>
-                    <v-container class="pa-0" fluid>
+                    <v-container
+                        class="pa-0"
+                        fluid
+                    >
                         <NuxtPage />
                         <AppNavMobile />
                     </v-container>

--- a/app/layouts/mobile.vue
+++ b/app/layouts/mobile.vue
@@ -3,22 +3,16 @@ const colorMode = useColorMode();
 </script>
 
 <template>
-    <ColorScheme>
-        <v-theme-provider
-            with-background
-            :theme="colorMode.preference"
-        >
-            <v-app>
-                <v-main>
-                    <v-container
-                        class="pa-0"
-                        fluid
-                    >
-                        <NuxtPage />
-                        <AppNavMobile />
-                    </v-container>
-                </v-main>
-            </v-app>
-        </v-theme-provider>
-    </ColorScheme>
+  <ColorScheme>
+    <v-theme-provider with-background :theme="colorMode.preference">
+      <v-app>
+        <v-main>
+          <v-container fluid>
+            <NuxtPage />
+            <AppNavMobile />
+          </v-container>
+        </v-main>
+      </v-app>
+    </v-theme-provider>
+  </ColorScheme>
 </template>

--- a/app/layouts/todo.vue
+++ b/app/layouts/todo.vue
@@ -3,26 +3,18 @@ const colorMode = useColorMode();
 </script>
 
 <template>
-    <ColorScheme>
-        <v-theme-provider
-            with-background
-            :theme="colorMode.preference"
-        >
-            <v-app>
-                <v-layout>
-                    <app-nav />
-                    <v-main>
-                        <v-container
-                            style="height: 100%"
-                            fluid
-                        >
-                            <v-row>
-                                <NuxtPage />
-                            </v-row>
-                        </v-container>
-                    </v-main>
-                </v-layout>
-            </v-app>
-        </v-theme-provider>
-    </ColorScheme>
+  <ColorScheme>
+    <v-theme-provider with-background :theme="colorMode.preference">
+      <v-app>
+        <v-layout>
+          <app-nav />
+          <v-main>
+            <v-container class="full-height px-8 py-4" fluid>
+              <NuxtPage />
+            </v-container>
+          </v-main>
+        </v-layout>
+      </v-app>
+    </v-theme-provider>
+  </ColorScheme>
 </template>

--- a/app/pages/(settings)/settings.vue
+++ b/app/pages/(settings)/settings.vue
@@ -3,8 +3,7 @@ definePageMeta({ layout: 'settings' });
 
 const { mdAndUp } = useDisplay();
 const store = useSettingsStore();
-const supabase = useSupabaseClient();
-const router = useRouter();
+
 const route = useRoute();
 
 const activeSection = ref('account');
@@ -25,15 +24,6 @@ async function checkGithubStatus() {
 }
 
 await useAsyncData(() => store.getUserSettings().then(() => true));
-
-async function signOut() {
-    const { error } = await supabase.auth.signOut();
-    if (error) {
-        console.error(error);
-        return;
-    }
-    router.push('/login');
-}
 
 onMounted(async () => {
     if (route.query.github === 'pending' && route.query.installation_id) {

--- a/app/pages/(settings)/settings/index.vue
+++ b/app/pages/(settings)/settings/index.vue
@@ -1,5 +1,0 @@
-<script setup lang="ts">
-await navigateTo('/settings/workflow', { replace: true });
-</script>
-
-<template></template>

--- a/app/pages/list/[id]/index.vue
+++ b/app/pages/list/[id]/index.vue
@@ -8,123 +8,99 @@ const currentTab = ref<ViewType>('list');
 const on = useToolbar();
 
 onBeforeMount(async () => {
-    await listsStore.getCurrentList();
+  await listsStore.getCurrentList();
 
-    const defaultView = listsStore.currentList?.defaultView as ViewType | undefined;
-    if (defaultView && tabs.value.includes(defaultView)) {
-        currentTab.value = defaultView;
-    }
+  const defaultView = listsStore.currentList?.defaultView as ViewType | undefined;
+  if (defaultView && tabs.value.includes(defaultView)) {
+    currentTab.value = defaultView;
+  }
 });
 
 if (!listsStore.currentList) {
-    navigateTo('/');
+  navigateTo('/');
 }
 
 if (listsStore.currentList) {
-    useHead({
-        title: `TickUp:${listsStore.currentList.name}`,
-    });
+  useHead({
+    title: `TickUp:${listsStore.currentList.name}`,
+  });
 }
 
 watch(listsStore.currentList.todos, (todos: Todo[]) => {
-    if (!todos) return;
-    on.value = todos.filter((todo: Todo) => todo.selected).length > 0;
+  if (!todos) return;
+  on.value = todos.filter((todo: Todo) => todo.selected).length > 0;
 });
 
 function updateListType(listType) {
-    console.log('updateListType', listType);
-    listsStore.currentList.listType = listType;
-    listsStore.updateList();
+  if (listType === 'table' && !listsStore.panelOpen) {
+    listsStore.panelOpen = false
+  }
+  listsStore.currentList.listType = listType;
+  listsStore.updateList();
 }
 </script>
 
 <template>
-    <v-container
-        fluid
-        class="fill-height"
-    >
-        <v-row class="fill-height">
-            <ListHeader />
-            <v-col
-                class="fill-height d-flex flex-column"
-                cols="12"
-            >
-                <v-tabs v-model="currentTab">
-                    <v-tab
-                        v-for="tab in tabs"
-                        :key="tab"
-                        :text="tab"
-                        :value="tab"
-                    />
-                </v-tabs>
-                <v-window
-                    v-model="currentTab"
-                    :touch="false"
-                    class="mt-4"
-                >
-                    <v-window-item
-                        value="board"
-                        class=""
-                    >
-                        <Board />
-                    </v-window-item>
-                    <v-window-item
-                        value="list"
-                        class="fill-height"
-                    >
-                        <v-row>
-                            <v-col>
-                                <TodoNew />
-                            </v-col>
-                            <v-col cols="auto">
-                                <ListType
-                                    :current-list-type="listsStore.currentList.listType"
-                                    @list-type-updated="(listType) => updateListType(listType)"
-                                />
-                            </v-col>
-                        </v-row>
-                        <div class="list-layout">
-                            <div class="list-layout__list">
-                                <ListTable v-if="listsStore.currentList.listType === 'table'" />
-                                <ListSimple v-else />
-                            </div>
-                            <Transition name="panel">
-                                <TodoPanel
-                                    v-if="listsStore.panelOpen"
-                                    @close="listsStore.panelOpen = false"
-                                />
-                            </Transition>
-                        </div>
-                    </v-window-item>
-                </v-window>
-            </v-col>
-        </v-row>
-    </v-container>
+  <v-container fluid class="fill-height">
+    <v-row class="fill-height">
+      <ListHeader />
+      <v-col class="fill-height d-flex flex-column" cols="12">
+        <v-tabs v-model="currentTab">
+          <v-tab v-for="tab in tabs" :key="tab" :text="tab" :value="tab" />
+        </v-tabs>
+        <v-window v-model="currentTab" :touch="false" class="mt-4">
+          <v-window-item value="board" class="">
+            <Board />
+          </v-window-item>
+          <v-window-item value="list" class="fill-height">
+            <v-row>
+              <v-col>
+                <TodoNew />
+              </v-col>
+              <v-col cols="auto">
+                <ListType :current-list-type="listsStore.currentList.listType"
+                  @list-type-updated="(listType) => updateListType(listType)" />
+              </v-col>
+            </v-row>
+            <div class="list-layout">
+              <div class="list-layout__list">
+                <ListTable v-if="listsStore.currentList.listType === 'table'" />
+                <ListSimple v-else />
+              </div>
+              <Transition name="panel">
+                <TodoPanel v-if="listsStore.panelOpen" @close="listsStore.panelOpen = false" />
+              </Transition>
+            </div>
+          </v-window-item>
+        </v-window>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <style scoped>
 .list-layout {
-    display: flex;
-    height: calc(100vh - 200px);
-    min-height: 0;
+  display: flex;
+  height: calc(100vh - 200px);
+  min-height: 0;
 }
 
 .list-layout__list {
-    flex: 1;
-    min-width: 0;
-    overflow-y: auto;
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
 }
 
 .panel-enter-active,
 .panel-leave-active {
-    transition:
-        transform 0.22s ease,
-        opacity 0.22s;
+  transition:
+    transform 0.22s ease,
+    opacity 0.22s;
 }
 
 .panel-enter-from,
 .panel-leave-to {
-    transform: translateX(20px);
-    opacity: 0;
+  transform: translateX(20px);
+  opacity: 0;
 }
 </style>

--- a/app/pages/todo/[id].vue
+++ b/app/pages/todo/[id].vue
@@ -1,200 +1,22 @@
-<script setup lang="ts">
-const route = useRoute();
-const listsStore = useListsStore();
-const parentTodo = ref<Todo | null>(null);
-const isLoading = ref(true);
-const transitionKey = ref(0);
-
-async function loadTodo(id: string | string[]) {
-    try {
-        isLoading.value = true;
-
-        const todo = await $fetch<Todo>(`/api/todo/${id}`);
-        listsStore.setCurrentTodo(todo);
-
-        // Explicitly fetch subtasks for this todo
-        await listsStore.fetchSubtasks(id as string);
-
-        // If this is a subtask, ensure we have the correct parent todo
-        if (todo.parentId) {
-            const needsNewParent = !parentTodo.value || parentTodo.value.id !== todo.parentId;
-            if (needsNewParent) {
-                parentTodo.value = await $fetch<Todo>(`/api/todo/${todo.parentId}`);
-            }
-        }
-        else {
-            // No parent for this todo
-            parentTodo.value = null;
-        }
-
-        if (todo && todo.listId) {
-            const list = await $fetch<List>(`/api/list/${todo.listId}`);
-            listsStore.setCurrentList(list);
-        }
-
-        // Only bump the transition key once everything for this todo is loaded,
-        // so the fade happens between fully-rendered states.
-        transitionKey.value++;
-    }
-    finally {
-        isLoading.value = false;
-    }
-}
-
-watch(
-    () => route.params.id,
-    (id) => {
-        if (id) loadTodo(id);
-    },
-    { immediate: true },
-);
-
-const backTo = computed(() => {
-    if (parentTodo.value) return `/todo/${parentTodo.value.id}`;
-    if (listsStore.currentTodo?.listId) return `/list/${listsStore.currentTodo.listId}`;
-    return '/';
-});
-
-const backLabel = computed(() => {
-    if (parentTodo.value) return parentTodo.value.name;
-    if (listsStore.currentList?.name) return listsStore.currentList.name;
-    return 'Home';
-});
-
-const backTestId = computed(() => {
-    if (parentTodo.value) return 'nav-back-parent';
-    if (listsStore.currentTodo?.listId && listsStore.currentList?.id) return 'nav-back-list';
-    return 'nav-back-home';
-});
-</script>
+<script setup lang="ts"></script>
 
 <template>
-    <NuxtErrorBoundary>
-        <template #error="{ error }">
-            <v-alert type="error">
-                {{ error }}
-            </v-alert>
-        </template>
+  <NuxtErrorBoundary>
+    <template #error="{ error }">
+      <v-alert type="error">
+        {{ error }}
+      </v-alert>
+    </template>
 
-        <!-- Breadcrumb bar -->
-        <div class="breadcrumb-bar">
-            <NuxtLink
-                v-if="!isLoading"
-                :data-testid="backTestId"
-                :to="backTo"
-                class="breadcrumb-back"
-            >
-                <i class="mdi mdi-arrow-left breadcrumb-back__icon" />
-            </NuxtLink>
-            <div
-                v-if="!isLoading"
-                class="breadcrumb-trail"
-            >
-                <NuxtLink
-                    :to="backTo"
-                    class="breadcrumb-segment breadcrumb-segment--parent"
-                >
-                    {{ backLabel }}
-                </NuxtLink>
-                <i class="mdi mdi-chevron-right breadcrumb-chevron" />
-                <span class="breadcrumb-segment breadcrumb-segment--current">
-                    {{ listsStore.currentTodo?.name }}
-                </span>
-            </div>
-        </div>
+    <v-row cols="12">
+      <AppBreadCrumb />
+    </v-row>
 
-        <!-- Main content -->
-        <div class="todo-page-surface">
-            <Transition name="todo-fade">
-                <TodoDetail :key="transitionKey" />
-            </Transition>
-        </div>
-    </NuxtErrorBoundary>
+    <!-- Main content -->
+    <v-row class="todo-page-surface">
+      <Transition name="todo-fade">
+        <TodoDetail />
+      </Transition>
+    </v-row>
+  </NuxtErrorBoundary>
 </template>
-
-<style scoped>
-.todo-fade-enter-active {
-    transition: opacity 0.18s ease;
-}
-
-.todo-fade-enter-from {
-    opacity: 0;
-}
-
-/* Breadcrumb bar */
-.breadcrumb-bar {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 10px 20px;
-    min-height: 48px;
-}
-
-.breadcrumb-back {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    border-radius: 8px;
-    color: rgba(var(--v-theme-on-surface), 0.6);
-    text-decoration: none;
-    transition: background 0.15s, color 0.15s;
-    flex-shrink: 0;
-}
-
-.breadcrumb-back:hover {
-    background: rgba(var(--v-border-color), 0.1);
-    color: rgb(var(--v-theme-on-surface));
-}
-
-.breadcrumb-back__icon {
-    font-size: 18px;
-}
-
-.breadcrumb-trail {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    min-width: 0;
-}
-
-.breadcrumb-segment {
-    font-size: 0.875rem;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.breadcrumb-segment--parent {
-    color: rgba(var(--v-theme-on-surface), 0.55);
-    text-decoration: none;
-    transition: color 0.15s;
-}
-
-.breadcrumb-segment--parent:hover {
-    color: rgb(var(--v-theme-primary));
-}
-
-.breadcrumb-segment--current {
-    color: rgb(var(--v-theme-on-surface));
-    font-weight: 500;
-    flex-shrink: 1;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.breadcrumb-chevron {
-    font-size: 14px;
-    color: rgba(var(--v-theme-on-surface), 0.35);
-    flex-shrink: 0;
-}
-
-/* Page surface */
-.todo-page-surface {
-    background: #f7f9fb;
-    min-height: calc(100vh - 120px);
-    padding: 0 12px 40px;
-}
-</style>

--- a/app/pages/todo/[id].vue
+++ b/app/pages/todo/[id].vue
@@ -21,8 +21,7 @@ async function loadTodo(id: string | string[]) {
             if (needsNewParent) {
                 parentTodo.value = await $fetch<Todo>(`/api/todo/${todo.parentId}`);
             }
-        }
-        else {
+        } else {
             // No parent for this todo
             parentTodo.value = null;
         }
@@ -35,8 +34,7 @@ async function loadTodo(id: string | string[]) {
         // Only bump the transition key once everything for this todo is loaded,
         // so the fade happens between fully-rendered states.
         transitionKey.value++;
-    }
-    finally {
+    } finally {
         isLoading.value = false;
     }
 }
@@ -48,6 +46,24 @@ watch(
     },
     { immediate: true },
 );
+
+const backTo = computed(() => {
+    if (parentTodo.value) return `/todo/${parentTodo.value.id}`;
+    if (listsStore.currentTodo?.listId) return `/list/${listsStore.currentTodo.listId}`;
+    return '/';
+});
+
+const backLabel = computed(() => {
+    if (parentTodo.value) return parentTodo.value.name;
+    if (listsStore.currentList?.name) return listsStore.currentList.name;
+    return 'Home';
+});
+
+const backTestId = computed(() => {
+    if (parentTodo.value) return 'nav-back-parent';
+    if (listsStore.currentTodo?.listId && listsStore.currentList?.id) return 'nav-back-list';
+    return 'nav-back-home';
+});
 </script>
 
 <template>
@@ -57,46 +73,34 @@ watch(
                 {{ error }}
             </v-alert>
         </template>
-        <v-col
-            cols="12"
-            style="height: 60px"
-        >
-            <v-btn
-                v-if="parentTodo"
-                data-testid="nav-back-parent"
-                :to="`/todo/${parentTodo.id}`"
+
+        <!-- Breadcrumb bar -->
+        <div class="breadcrumb-bar">
+            <NuxtLink
+                v-if="!isLoading"
+                :data-testid="backTestId"
+                :to="backTo"
+                class="breadcrumb-back"
             >
-                <template #prepend>
-                    <v-icon>mdi-arrow-left</v-icon>
-                </template>
-                {{ parentTodo.name }}
-            </v-btn>
-            <v-btn
-                v-else-if="listsStore.currentTodo?.listId && listsStore.currentList?.id"
-                data-testid="nav-back-list"
-                :to="`/list/${listsStore.currentTodo.listId}`"
-            >
-                <template #prepend>
-                    <v-icon>mdi-arrow-left</v-icon>
-                </template>
-                {{ listsStore.currentList.name }}
-            </v-btn>
-            <v-btn
-                v-else-if="!isLoading"
-                data-testid="nav-back-home"
-                to="/"
-            >
-                <template #prepend>
-                    <v-icon>mdi-arrow-left</v-icon>
-                </template>
-                Home
-            </v-btn>
-        </v-col>
-        <v-col>
+                <i class="mdi mdi-arrow-left breadcrumb-back__icon" />
+            </NuxtLink>
+            <div v-if="!isLoading" class="breadcrumb-trail">
+                <NuxtLink :to="backTo" class="breadcrumb-segment breadcrumb-segment--parent">
+                    {{ backLabel }}
+                </NuxtLink>
+                <i class="mdi mdi-chevron-right breadcrumb-chevron" />
+                <span class="breadcrumb-segment breadcrumb-segment--current">
+                    {{ listsStore.currentTodo?.name }}
+                </span>
+            </div>
+        </div>
+
+        <!-- Main content -->
+        <div class="todo-page-surface">
             <Transition name="todo-fade">
                 <TodoDetail :key="transitionKey" />
             </Transition>
-        </v-col>
+        </div>
     </NuxtErrorBoundary>
 </template>
 
@@ -107,5 +111,82 @@ watch(
 
 .todo-fade-enter-from {
     opacity: 0;
+}
+
+/* Breadcrumb bar */
+.breadcrumb-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 20px;
+    min-height: 48px;
+}
+
+.breadcrumb-back {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    color: rgba(var(--v-theme-on-surface), 0.6);
+    text-decoration: none;
+    transition: background 0.15s, color 0.15s;
+    flex-shrink: 0;
+}
+
+.breadcrumb-back:hover {
+    background: rgba(var(--v-border-color), 0.1);
+    color: rgb(var(--v-theme-on-surface));
+}
+
+.breadcrumb-back__icon {
+    font-size: 18px;
+}
+
+.breadcrumb-trail {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+}
+
+.breadcrumb-segment {
+    font-size: 0.875rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.breadcrumb-segment--parent {
+    color: rgba(var(--v-theme-on-surface), 0.55);
+    text-decoration: none;
+    transition: color 0.15s;
+}
+
+.breadcrumb-segment--parent:hover {
+    color: rgb(var(--v-theme-primary));
+}
+
+.breadcrumb-segment--current {
+    color: rgb(var(--v-theme-on-surface));
+    font-weight: 500;
+    flex-shrink: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.breadcrumb-chevron {
+    font-size: 14px;
+    color: rgba(var(--v-theme-on-surface), 0.35);
+    flex-shrink: 0;
+}
+
+/* Page surface */
+.todo-page-surface {
+    background: #f7f9fb;
+    min-height: calc(100vh - 120px);
+    padding: 0 12px 40px;
 }
 </style>

--- a/app/pages/todo/[id].vue
+++ b/app/pages/todo/[id].vue
@@ -21,7 +21,8 @@ async function loadTodo(id: string | string[]) {
             if (needsNewParent) {
                 parentTodo.value = await $fetch<Todo>(`/api/todo/${todo.parentId}`);
             }
-        } else {
+        }
+        else {
             // No parent for this todo
             parentTodo.value = null;
         }
@@ -34,7 +35,8 @@ async function loadTodo(id: string | string[]) {
         // Only bump the transition key once everything for this todo is loaded,
         // so the fade happens between fully-rendered states.
         transitionKey.value++;
-    } finally {
+    }
+    finally {
         isLoading.value = false;
     }
 }
@@ -84,8 +86,14 @@ const backTestId = computed(() => {
             >
                 <i class="mdi mdi-arrow-left breadcrumb-back__icon" />
             </NuxtLink>
-            <div v-if="!isLoading" class="breadcrumb-trail">
-                <NuxtLink :to="backTo" class="breadcrumb-segment breadcrumb-segment--parent">
+            <div
+                v-if="!isLoading"
+                class="breadcrumb-trail"
+            >
+                <NuxtLink
+                    :to="backTo"
+                    class="breadcrumb-segment breadcrumb-segment--parent"
+                >
                     {{ backLabel }}
                 </NuxtLink>
                 <i class="mdi mdi-chevron-right breadcrumb-chevron" />


### PR DESCRIPTION
## Summary

- Replaces the single-column todo detail layout with a two-column CSS grid (left: `1fr`, right: `248px` sidebar) on `md+` screens; stacks vertically on mobile with the sidebar above the main content
- Adds a breadcrumb bar at the top of the todo page (`[List / Parent] > [Todo name]`) with a back arrow, replacing the old plain `v-btn` navigation
- Moves Status pill, Due date, List, and GitHub link into a right-side properties card (white card, `border-radius: 8px`, `box-shadow: 0 8px 32px rgba(42,52,57,.06)`); overdue dates render in red `#ba1b24`
- Adds Delete button in the sidebar that confirms via dialog then navigates to the list (or home) after deletion

## Test plan

- [ ] Open a todo that belongs to a list — breadcrumb shows `List name > Todo name`
- [ ] Open a subtask — breadcrumb shows `Parent todo name > Subtask name`
- [ ] Click the back arrow or parent segment — navigates correctly
- [ ] On a wide screen (≥ 960px): left card (title, description, subtasks, links) and right sidebar card render side-by-side
- [ ] On mobile (< 960px): sidebar stacks above main content
- [ ] Status pill opens dropdown and updates status
- [ ] Due date shows red when overdue and todo is not Closed
- [ ] Delete button opens confirm dialog; confirming deletes the todo and navigates away
- [ ] Existing `data-testid` attributes (`nav-back-parent`, `nav-back-list`, `nav-back-home`, `todo-detail-title`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhzZGKWB927CqkeMsPo64H

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhzZGKWB927CqkeMsPo64H)_