### PR TITLE
Add API tests for todo CRUD and subtasks

### DIFF
--- a/e2e/api/todos/delete-todo.spec.ts
+++ b/e2e/api/todos/delete-todo.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "@playwright/test";
+import { v4 as uuidv4 } from "uuid";
+import { createTodo } from "../helpers/todos";
+
+test.describe("Delete a todo", () => {
+  test("should delete a todo and return the deleted todo", async ({
+    request,
+  }) => {
+    const testId = uuidv4();
+    const todo = await createTodo(request, {
+      name: `To delete ${testId}`,
+      dueDate: new Date(),
+    });
+
+    expect(todo.id).toBeTruthy();
+
+    const response = await request.delete(`/api/todo/${todo.id}`);
+    expect(response.status()).toEqual(200);
+
+    const deleted = await response.json();
+    expect(deleted.id).toEqual(todo.id);
+    expect(deleted.name).toEqual(`To delete ${testId}`);
+  });
+
+  test("should return 404 when getting a todo after deletion", async ({
+    request,
+  }) => {
+    const testId = uuidv4();
+    const todo = await createTodo(request, {
+      name: `To delete then check ${testId}`,
+      dueDate: new Date(),
+    });
+
+    expect(todo.id).toBeTruthy();
+
+    // Delete the todo
+    const deleteResponse = await request.delete(`/api/todo/${todo.id}`);
+    expect(deleteResponse.status()).toEqual(200);
+
+    // Now verify it no longer exists
+    const getResponse = await request.get(`/api/todo/${todo.id}`);
+    expect(getResponse.status()).toEqual(404);
+  });
+
+  test("should return an error when deleting a todo that does not exist", async ({
+    request,
+  }) => {
+    const nonExistentId = uuidv4();
+    const response = await request.delete(`/api/todo/${nonExistentId}`);
+    expect([404, 500]).toContain(response.status());
+  });
+});

--- a/e2e/api/todos/get-subtasks.spec.ts
+++ b/e2e/api/todos/get-subtasks.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect } from "@playwright/test";
+import { v4 as uuidv4 } from "uuid";
+import { createTodo } from "../helpers/todos";
+
+test.describe("Get subtasks of a todo", () => {
+  test("should return subtasks for a parent todo", async ({ request }) => {
+    const testId = uuidv4();
+    const parent = await createTodo(request, {
+      name: `Parent ${testId}`,
+      dueDate: new Date(),
+    });
+
+    const child = await createTodo(request, {
+      name: `Child ${testId}`,
+      dueDate: new Date(),
+      parentId: parent.id,
+    });
+
+    const response = await request.get(`/api/todo/${parent.id}/subtasks`);
+    expect(response.status()).toEqual(200);
+
+    const subtasks = await response.json();
+    expect(subtasks).toHaveLength(1);
+    expect(subtasks[0].id).toEqual(child.id);
+    expect(subtasks[0].name).toEqual(`Child ${testId}`);
+    expect(subtasks[0].parentId).toEqual(parent.id);
+  });
+
+  test("should return empty array when todo has no subtasks", async ({
+    request,
+  }) => {
+    const testId = uuidv4();
+    const parent = await createTodo(request, {
+      name: `No Children ${testId}`,
+      dueDate: new Date(),
+    });
+
+    const response = await request.get(`/api/todo/${parent.id}/subtasks`);
+    expect(response.status()).toEqual(200);
+
+    const subtasks = await response.json();
+    expect(subtasks).toEqual([]);
+  });
+
+  test("should return all subtasks when a parent has multiple children", async ({
+    request,
+  }) => {
+    const testId = uuidv4();
+    const parent = await createTodo(request, {
+      name: `Multi-Child Parent ${testId}`,
+      dueDate: new Date(),
+    });
+
+    const child1 = await createTodo(request, {
+      name: `Child One ${testId}`,
+      dueDate: new Date(),
+      parentId: parent.id,
+    });
+
+    const child2 = await createTodo(request, {
+      name: `Child Two ${testId}`,
+      dueDate: new Date(),
+      parentId: parent.id,
+    });
+
+    const child3 = await createTodo(request, {
+      name: `Child Three ${testId}`,
+      dueDate: new Date(),
+      parentId: parent.id,
+    });
+
+    const response = await request.get(`/api/todo/${parent.id}/subtasks`);
+    expect(response.status()).toEqual(200);
+
+    const subtasks = await response.json();
+    expect(subtasks).toHaveLength(3);
+
+    const ids = subtasks.map((s: { id: string }) => s.id);
+    expect(ids).toContain(child1.id);
+    expect(ids).toContain(child2.id);
+    expect(ids).toContain(child3.id);
+
+    subtasks.forEach((s: { parentId: string }) => {
+      expect(s.parentId).toEqual(parent.id);
+    });
+  });
+
+  test("should not return subtasks belonging to a different parent", async ({
+    request,
+  }) => {
+    const testId = uuidv4();
+
+    const parentA = await createTodo(request, {
+      name: `Parent A ${testId}`,
+      dueDate: new Date(),
+    });
+
+    const parentB = await createTodo(request, {
+      name: `Parent B ${testId}`,
+      dueDate: new Date(),
+    });
+
+    await createTodo(request, {
+      name: `Child of B ${testId}`,
+      dueDate: new Date(),
+      parentId: parentB.id,
+    });
+
+    const response = await request.get(`/api/todo/${parentA.id}/subtasks`);
+    expect(response.status()).toEqual(200);
+
+    const subtasks = await response.json();
+    expect(subtasks).toEqual([]);
+  });
+
+  test("should return empty array for a non-existent todo id", async ({
+    request,
+  }) => {
+    // Use 0 — a valid integer that will never match a real todo id
+    const response = await request.get(`/api/todo/0/subtasks`);
+    expect(response.status()).toEqual(200);
+
+    const subtasks = await response.json();
+    expect(subtasks).toEqual([]);
+  });
+
+  test("should return 500 when id is not a valid integer", async ({
+    request,
+  }) => {
+    // The DB column is an integer; passing a UUID causes a type error -> 500
+    const nonExistentId = uuidv4();
+    const response = await request.get(`/api/todo/${nonExistentId}/subtasks`);
+    expect(response.status()).toEqual(500);
+  });
+});

--- a/e2e/api/todos/get-todo.spec.ts
+++ b/e2e/api/todos/get-todo.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+import { v4 as uuidv4 } from "uuid";
+import { createTodo } from "../helpers/todos";
+
+test.describe("Get a todo", () => {
+  test("should return a todo by id", async ({ request }) => {
+    const testId = uuidv4();
+    const created = await createTodo(request, {
+      name: `Get Todo ${testId}`,
+      dueDate: new Date(),
+    });
+
+    expect(created.id).toBeTruthy();
+
+    const response = await request.get(`/api/todo/${created.id}`);
+    expect(response.status()).toEqual(200);
+
+    const todo = await response.json();
+    expect(todo.id).toEqual(created.id);
+    expect(todo.name).toEqual(`Get Todo ${testId}`);
+    expect(todo.status).toBeTruthy();
+  });
+
+  test("should return 404 for a todo that does not exist", async ({
+    request,
+  }) => {
+    const nonExistentId = uuidv4();
+    const response = await request.get(`/api/todo/${nonExistentId}`);
+    expect(response.status()).toEqual(404);
+  });
+
+  test("should return all key fields for a retrieved todo", async ({
+    request,
+  }) => {
+    const testId = uuidv4();
+    const created = await createTodo(request, {
+      name: `Full Fields Todo ${testId}`,
+      dueDate: new Date(),
+    });
+
+    const response = await request.get(`/api/todo/${created.id}`);
+    expect(response.status()).toEqual(200);
+
+    const todo = await response.json();
+    expect(todo.id).toEqual(created.id);
+    expect(todo.name).toEqual(`Full Fields Todo ${testId}`);
+    expect(todo.status).toBeTruthy();
+    expect(todo.color).toBeTruthy();
+    expect(todo.priorityLev).toBeDefined();
+  });
+});

--- a/e2e/api/todos/update-todo.spec.ts
+++ b/e2e/api/todos/update-todo.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from "@playwright/test";
+import { v4 as uuidv4 } from "uuid";
+import { createTodo } from "../helpers/todos";
+
+test.describe("Update a todo", () => {
+  test("should update a todo name", async ({ request }) => {
+    const testId = uuidv4();
+    const created = await createTodo(request, {
+      name: `Original ${testId}`,
+      dueDate: new Date(),
+    });
+
+    expect(created.id).toBeTruthy();
+
+    const response = await request.put(`/api/todo/${created.id}`, {
+      data: { ...created, name: `Updated ${testId}` },
+    });
+
+    expect(response.status()).toEqual(200);
+
+    const updated = await response.json();
+    expect(updated.name).toEqual(`Updated ${testId}`);
+    expect(updated.id).toEqual(created.id);
+  });
+
+  test("should update a todo status", async ({ request }) => {
+    const testId = uuidv4();
+    const created = await createTodo(request, {
+      name: `Status Todo ${testId}`,
+      dueDate: new Date(),
+    });
+
+    expect(created.id).toBeTruthy();
+    expect(created.status).toEqual("Open");
+
+    const response = await request.put(`/api/todo/${created.id}`, {
+      data: { ...created, status: "Done" },
+    });
+
+    expect(response.status()).toEqual(200);
+
+    const updated = await response.json();
+    expect(updated.status).toEqual("Done");
+    expect(updated.id).toEqual(created.id);
+  });
+
+  test("should return 500 when updating a todo that does not exist", async ({
+    request,
+  }) => {
+    const nonExistentId = uuidv4();
+    const response = await request.put(`/api/todo/${nonExistentId}`, {
+      data: {
+        name: "Ghost Todo",
+        status: "Open",
+        desc: "",
+        color: "#87909e",
+        priorityLev: "",
+        links: [],
+        attachments: [],
+      },
+    });
+
+    expect(response.status()).toEqual(500);
+  });
+
+  test("should persist updated fields after a subsequent fetch", async ({
+    request,
+  }) => {
+    const testId = uuidv4();
+    const created = await createTodo(request, {
+      name: `Persist Check ${testId}`,
+      dueDate: new Date(),
+    });
+
+    expect(created.id).toBeTruthy();
+
+    const putResponse = await request.put(`/api/todo/${created.id}`, {
+      data: { ...created, name: `Persisted ${testId}`, status: "In Progress" },
+    });
+
+    expect(putResponse.status()).toEqual(200);
+
+    const getResponse = await request.get(`/api/todo/${created.id}`);
+    expect(getResponse.status()).toEqual(200);
+
+    const fetched = await getResponse.json();
+    expect(fetched.name).toEqual(`Persisted ${testId}`);
+    expect(fetched.status).toEqual("In Progress");
+  });
+});


### PR DESCRIPTION
## Summary
- GET /api/todo/:id — happy path, 404 for non-existent
- PUT /api/todo/:id — name update, status update, error on non-existent, field persistence check
- DELETE /api/todo/:id — returns deleted todo, 404 after deletion, error on non-existent
- GET /api/todo/:id/subtasks — single/multiple subtasks, empty array, cross-parent isolation, invalid ID types

## Test plan
- [x] 19/19 API tests pass locally (`pnpm test:api`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)