### PR TITLE
feat(github): add view PR link button

### DIFF
--- a/app/components/Github/Button.vue
+++ b/app/components/Github/Button.vue
@@ -111,6 +111,7 @@ onUnmounted(() => {
                         <GithubBranchOpen />
                         <GithubBranchOpenInIde />
                         <GithubBranchCreate />
+                        <GithubPROpen />
                     </template>
                 </v-text-field>
             </v-list-item>

--- a/app/components/Github/PR/Open.vue
+++ b/app/components/Github/PR/Open.vue
@@ -7,6 +7,7 @@ const listStore = useListsStore();
         v-if="listStore.currentTodo.githubPrLink"
         size="small"
         icon="mdi-source-pull"
+        color="green"
         @click.stop="navigateTo(listStore.currentTodo.githubPrLink, { open: { target: '_blank' } })"
     />
 </template>

--- a/app/components/Github/PR/Open.vue
+++ b/app/components/Github/PR/Open.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+const listStore = useListsStore();
+</script>
+
+<template>
+    <v-btn
+        v-if="listStore.currentTodo.githubPrLink"
+        size="small"
+        icon="mdi-source-pull"
+        :href="listStore.currentTodo.githubPrLink"
+        target="_blank"
+    />
+</template>

--- a/app/components/Github/PR/Open.vue
+++ b/app/components/Github/PR/Open.vue
@@ -7,6 +7,6 @@ const listStore = useListsStore();
         v-if="listStore.currentTodo.githubPrLink"
         size="small"
         icon="mdi-source-pull"
-        @click.stop="window.open(listStore.currentTodo.githubPrLink, '_blank')"
+        @click.stop="navigateTo(listStore.currentTodo.githubPrLink, { open: { target: '_blank' } })"
     />
 </template>

--- a/app/components/Github/PR/Open.vue
+++ b/app/components/Github/PR/Open.vue
@@ -7,7 +7,6 @@ const listStore = useListsStore();
         v-if="listStore.currentTodo.githubPrLink"
         size="small"
         icon="mdi-source-pull"
-        :href="listStore.currentTodo.githubPrLink"
-        target="_blank"
+        @click.stop="window.open(listStore.currentTodo.githubPrLink, '_blank')"
     />
 </template>

--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ declare global {
         githubBranchName?: string;
         githubRepo?: string;
         githubLink?: string;
+        githubPrLink?: string;
         links: {
             id?: string;
             title: string;

--- a/server/api/github/webhook/events.ts
+++ b/server/api/github/webhook/events.ts
@@ -28,17 +28,31 @@ export async function handlePullRequest(
     supabase,
     body: PullRequestEvent,
     subscribedUserIds,
-    branchName,
+    _branchName,
 ) {
     const pr = body.pull_request;
-    const merged = pr?.merged;
+    const prBranchName = pr?.head?.ref;
 
-    if (merged) {
+    if (!prBranchName) return;
+
+    if (body.action === 'opened') {
+        const { error } = await supabase
+            .from('Todos')
+            .update({ github_pr_link: pr.html_url })
+            .in('user_id', subscribedUserIds)
+            .eq('github_branch_name', prBranchName);
+
+        if (error) {
+            console.error('Error updating todo github_pr_link for pull request event:', error);
+        }
+    }
+
+    if (pr?.merged) {
         const { error } = await supabase
             .from('Todos')
             .update({ status: 'Closed' })
             .in('user_id', subscribedUserIds)
-            .eq('github_branch_name', branchName);
+            .eq('github_branch_name', prBranchName);
 
         if (error) {
             console.error('Error updating todo status for pull request event:', error);

--- a/supabase/migrations/20260628000000_github_pr_link.sql
+++ b/supabase/migrations/20260628000000_github_pr_link.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."Todos" ADD COLUMN github_pr_link text;


### PR DESCRIPTION
## Summary
- Adds `github_pr_link` column to `Todos` via migration
- Saves PR URL automatically when a GitHub PR webhook fires (`opened` action)
- Shows a `mdi-source-pull` icon button in the GitHub menu — only visible when a PR link exists — that opens the PR in a new tab

## Test plan
- [ ] Link a GitHub branch to a todo
- [ ] Open a PR against that branch on GitHub
- [ ] Verify the PR icon appears in the todo's GitHub menu
- [ ] Click it and confirm it opens the PR in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GitHub PR shortcut in the command panel, letting you open the related pull request directly when available.
  * Todo items can now store and surface a GitHub pull request link.

* **Bug Fixes**
  * Improved GitHub pull request handling so opened PRs are linked correctly and completed items update more reliably based on the PR branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->