### PR TITLE
Fix new todos not persisting to homepage due-date filters

### DIFF
--- a/app/components/App/Nav/Mobile.vue
+++ b/app/components/App/Nav/Mobile.vue
@@ -68,6 +68,7 @@ function isActive(to: string) {
         <div class="mobile-nav__fab-wrap">
             <button
                 class="mobile-nav__fab"
+                data-testid="mobile-new-todo-fab"
                 @click="
                     dialog.page = 'todo';
                     dialog.open = true;

--- a/app/stores/lists.ts
+++ b/app/stores/lists.ts
@@ -183,17 +183,17 @@ export const useListsStore = defineStore('lists', {
         setTodoDetails(todo: Task) {
             this.addListId(todo);
 
-            const now = new Date();
-
-            this.setNewTodoDueDate(now);
+            this.setNewTodoDueDate(todo);
         },
         addListId(todo) {
             if (!todo.listId) {
                 todo.listId = this?.currentList?.id;
             }
         },
-        setNewTodoDueDate(newDueDate: Date) {
-            this.newTodo.dueDate = newDueDate;
+        setNewTodoDueDate(todo: Task) {
+            if (!todo.dueDate) {
+                todo.dueDate = new Date();
+            }
         },
         async updateTodo(todo?: Task) {
             if (!todo) {

--- a/e2e/app/homepage/create-todo-dialog-persists.spec.ts
+++ b/e2e/app/homepage/create-todo-dialog-persists.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '../../fixtures/index';
+import { v4 as uuidv4 } from 'uuid';
+import { deleteLists } from '../../helpers/teardown';
+
+test.describe('Homepage - todo created via the new-task dialog persists', () => {
+    test.beforeEach(async ({ page, isMobile }) => {
+        test.skip(isMobile, 'This feature is desktop only');
+
+        await deleteLists();
+
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+    });
+
+    test('a todo created without picking a due date is still shown after reload', async ({
+        page,
+        isMobile,
+    }) => {
+        test.skip(isMobile, 'This feature is desktop only');
+
+        const todoName = `Dialog todo ${uuidv4()}`;
+
+        // Open the "New Task" dialog the same way the homepage's `t` shortcut does,
+        // and only fill in the name - regression coverage for a bug where todos
+        // created this way were saved with a null due date and then silently
+        // dropped from the homepage's "today" list on the next refetch.
+        await page.keyboard.press('t');
+        await expect(page.getByTestId('dialog-title')).toHaveText('New Task');
+
+        const newTodoInput = page.getByTestId('new-todo-input').locator('input');
+        await newTodoInput.fill(todoName);
+
+        const responsePromise = page.waitForResponse('**/api/todo');
+        await page.getByTestId('create-todo-button').click();
+
+        const response = await responsePromise;
+        expect(response.status()).toBe(200);
+        const created: Todo = await response.json();
+        expect(created.dueDate).toBeTruthy();
+
+        await expect(page.getByTestId('todo-title').filter({ hasText: todoName })).toBeVisible();
+
+        // The bug only showed up once the homepage refetched todaysTodos from the
+        // server (due_date filter), so a reload is required to catch it.
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+
+        await expect(page.getByTestId('todo-title').filter({ hasText: todoName })).toBeVisible();
+    });
+});

--- a/e2e/app/homepage/create-todo-dialog-persists.spec.ts
+++ b/e2e/app/homepage/create-todo-dialog-persists.spec.ts
@@ -3,9 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { deleteLists } from '../../helpers/teardown';
 
 test.describe('Homepage - todo created via the new-task dialog persists', () => {
-    test.beforeEach(async ({ page, isMobile }) => {
-        test.skip(isMobile, 'This feature is desktop only');
-
+    test.beforeEach(async ({ page }) => {
         await deleteLists();
 
         await page.goto('/');
@@ -16,15 +14,19 @@ test.describe('Homepage - todo created via the new-task dialog persists', () => 
         page,
         isMobile,
     }) => {
-        test.skip(isMobile, 'This feature is desktop only');
-
         const todoName = `Dialog todo ${uuidv4()}`;
 
-        // Open the "New Task" dialog the same way the homepage's `t` shortcut does,
-        // and only fill in the name - regression coverage for a bug where todos
-        // created this way were saved with a null due date and then silently
-        // dropped from the homepage's "today" list on the next refetch.
-        await page.keyboard.press('t');
+        // Open the "New Task" dialog the same way a user would on this device -
+        // the `t` shortcut on desktop, the bottom-nav FAB on mobile - and only
+        // fill in the name. Regression coverage for a bug where todos created
+        // this way were saved with a null due date and then silently dropped
+        // from the homepage's "today" list on the next refetch.
+        if (isMobile) {
+            await page.getByTestId('mobile-new-todo-fab').click();
+        }
+        else {
+            await page.keyboard.press('t');
+        }
         await expect(page.getByTestId('dialog-title')).toHaveText('New Task');
 
         const newTodoInput = page.getByTestId('new-todo-input').locator('input');

--- a/test/nuxt/lists-todo-due-date.test.ts
+++ b/test/nuxt/lists-todo-due-date.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { useListsStore } from '../../app/stores/lists';
+
+describe('lists store - setTodoDetails', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it('defaults a missing due date on the todo being submitted, not on newTodo', () => {
+        const store = useListsStore();
+        const todo = { name: 'Test todo' } as Task;
+
+        store.setTodoDetails(todo);
+
+        expect(todo.dueDate).toBeInstanceOf(Date);
+        // Regression guard: the bug set `this.newTodo.dueDate` instead of
+        // `todo.dueDate`, which left the todo actually sent to /api/todo
+        // without a due date whenever it wasn't the same object as newTodo
+        // (e.g. the global TodoDialog). A todo with no due_date never matches
+        // the homepage's Today/Overdue queries and silently vanished on the
+        // next refetch.
+        expect(store.newTodo.dueDate).toBeUndefined();
+    });
+
+    it('preserves an already chosen due date', () => {
+        const store = useListsStore();
+        const chosen = new Date('2030-01-01T00:00:00Z');
+        const todo = { name: 'Test todo', dueDate: chosen } as Task;
+
+        store.setTodoDetails(todo);
+
+        expect(todo.dueDate).toBe(chosen);
+    });
+});


### PR DESCRIPTION
setNewTodoDueDate mutated this.newTodo.dueDate instead of the todo
object actually being submitted, so todos created via the global
TodoDialog (the primary homepage "+"/`t` creation path) were saved
with a null due_date. The homepage's Today/Overdue queries filter
strictly on due_date, so these todos vanished on the next refetch
even though they were persisted to Supabase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved due-date handling when creating or editing tasks.
  * Ensured missing due dates are assigned directly to the relevant task, preventing incorrect date updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->