### PR TITLE
Fix failing e2e tests broken by the nav/settings redesign

### DIFF
--- a/app/components/App/ContextMenu.vue
+++ b/app/components/App/ContextMenu.vue
@@ -7,6 +7,7 @@ export interface ContextMenuItem {
     shortcut?: string;
     danger?: boolean;
     divider?: boolean;
+    testId?: string;
     onClick?: () => void;
 }
 
@@ -80,6 +81,7 @@ onUnmounted(() => {
                     v-else
                     class="ctx-item"
                     :class="{ 'ctx-item--danger': item.danger }"
+                    :data-testid="item.testId"
                     @click="
                         item.onClick?.();
                         emit('close');

--- a/app/components/App/Nav/Items.vue
+++ b/app/components/App/Nav/Items.vue
@@ -45,6 +45,7 @@ function menuItems(list: List): ContextMenuItem[] {
             icon: 'mdi-trash-can-outline',
             label: 'Delete',
             danger: true,
+            testId: 'delete-list-menu-item',
             onClick: () => {
                 confirmId.value = list.id ?? null;
             },

--- a/app/components/App/Nav/Items.vue
+++ b/app/components/App/Nav/Items.vue
@@ -101,6 +101,7 @@ onUnmounted(() => {
         <button
             class="nav-add-btn"
             title="New list"
+            data-testid="new-list-button"
             @click="
                 dialog.page = 'list';
                 dialog.open = true;
@@ -123,6 +124,8 @@ onUnmounted(() => {
                 'nav-row--active': listsStore.currentList?.id === list.id,
                 'nav-row--editing': editingId === list.id,
             }"
+            :data-test-id="list.name"
+            :data-list-id="list.id"
             @click="editingId !== list.id && navigateTo(`/list/${list.id}`)"
             @contextmenu.prevent="openMenuAt(list.id!, $event.clientX, $event.clientY)"
         >

--- a/app/components/List/Simple.vue
+++ b/app/components/List/Simple.vue
@@ -79,7 +79,10 @@ const closedTodos = computed(
                     :style="{ border: `2px solid ${statusColor(todo.status)}` }"
                     @click.stop="toggleTodo(todo)"
                 />
-                <span class="flex-grow-1 text-truncate text-body-2 font-weight-medium todo-name">
+                <span
+                    class="flex-grow-1 text-truncate text-body-2 font-weight-medium todo-name"
+                    data-testid="todo-title"
+                >
                     {{ todo.name }}
                 </span>
                 <v-icon
@@ -141,7 +144,10 @@ const closedTodos = computed(
                             mdi-check
                         </v-icon>
                     </button>
-                    <span class="flex-grow-1 text-truncate text-body-2 font-weight-medium todo-name todo-name--done">
+                    <span
+                        class="flex-grow-1 text-truncate text-body-2 font-weight-medium todo-name todo-name--done"
+                        data-testid="todo-title"
+                    >
                         {{ todo.name }}
                     </span>
                     <span

--- a/app/pages/list/[id]/index.vue
+++ b/app/pages/list/[id]/index.vue
@@ -84,7 +84,10 @@ const views: { key: View; icon: string; label: string }[] = [
                 </v-row>
 
                 <!-- Add task bar -->
-                <div class="add-task-bar d-flex align-center px-4 mb-5 ga-3">
+                <div
+                    class="add-task-bar d-flex align-center px-4 mb-5 ga-3"
+                    data-testid="new-todo-input"
+                >
                     <v-icon
                         color="primary"
                         size="18"

--- a/e2e/app/homepage/create-todo-dialog-persists.spec.ts
+++ b/e2e/app/homepage/create-todo-dialog-persists.spec.ts
@@ -29,7 +29,9 @@ test.describe('Homepage - todo created via the new-task dialog persists', () => 
         }
         await expect(page.getByTestId('dialog-title')).toHaveText('New Task');
 
-        const newTodoInput = page.getByTestId('new-todo-input').locator('input');
+        // Scope to the dialog: the homepage also renders an inline "Add todo"
+        // field with the same test id, so an unscoped locator is ambiguous.
+        const newTodoInput = page.getByRole('dialog').getByTestId('new-todo-input').locator('input');
         await newTodoInput.fill(todoName);
 
         const responsePromise = page.waitForResponse('**/api/todo');

--- a/e2e/lists/create-list.spec.ts
+++ b/e2e/lists/create-list.spec.ts
@@ -22,15 +22,18 @@ test.describe('a user can create a list', () => {
         const listName = `List ${testId}`;
         const newListInput = await page.getByRole('textbox', { name: 'New List' });
         await newListInput.type(listName);
-        const requestPromise = page.waitForRequest(
-            request => request.url().includes('/api/list') && request.method() === 'POST',
+        const responsePromise = page.waitForResponse(
+            response => response.url().includes('/api/list') && response.request().method() === 'POST',
         );
         await page.keyboard.press('Enter');
-        await requestPromise;
+        const createResponse = await responsePromise;
+        const created = await createResponse.json();
 
         await page.waitForTimeout(500);
 
-        const newListNavItem = await page.locator(`[data-test-id="${listName}"]`);
+        // Select by list id (not the user-entered name) since names can
+        // contain characters that are unsafe to interpolate into a CSS selector.
+        const newListNavItem = await page.locator(`[data-list-id="${created.id}"]`);
 
         expect(newListNavItem).not.toBeHidden();
     });
@@ -55,15 +58,18 @@ test.describe('a user can create a list', () => {
         const listName = `List ${testId}`;
         const newListInput = await page.getByRole('textbox', { name: 'New List' });
         await newListInput.type(listName);
-        const requestPromise = page.waitForRequest(
-            request => request.url().includes('/api/list') && request.method() === 'POST',
+        const responsePromise = page.waitForResponse(
+            response => response.url().includes('/api/list') && response.request().method() === 'POST',
         );
         await page.keyboard.press('Enter');
 
-        await requestPromise;
+        const createResponse = await responsePromise;
+        const created = await createResponse.json();
         await page.waitForTimeout(500);
 
-        const newListNavItem = await page.locator(`[data-test-id="${listName}"]`);
+        // Select by list id (not the user-entered name) since names can
+        // contain characters that are unsafe to interpolate into a CSS selector.
+        const newListNavItem = await page.locator(`[data-list-id="${created.id}"]`);
 
         expect(newListNavItem).not.toBeHidden();
     });

--- a/e2e/lists/delete-list.spec.ts
+++ b/e2e/lists/delete-list.spec.ts
@@ -47,7 +47,7 @@ test.describe('a user can delete a list', () => {
 
         // Opens a context menu with a "Delete" item; selecting it reveals a
         // confirmation dialog with the actual delete action.
-        const deleteMenuItem = page.getByRole('button', { name: 'Delete', exact: true });
+        const deleteMenuItem = page.getByTestId('delete-list-menu-item');
         await expect(deleteMenuItem).toBeVisible();
         await deleteMenuItem.click();
 

--- a/e2e/lists/delete-list.spec.ts
+++ b/e2e/lists/delete-list.spec.ts
@@ -33,10 +33,12 @@ test.describe('a user can delete a list', () => {
     test('using the settings menu', async ({ page, request }) => {
         await page.waitForLoadState('networkidle');
 
-        const newListNavItem = page.locator(`[data-test-id="${listName}"]`);
-        await expect(newListNavItem).toBeVisible();
-
         expect(listId).toBeTruthy();
+
+        // Select by list id (not the user-entered name) since names can
+        // contain characters that are unsafe to interpolate into a CSS selector.
+        const newListNavItem = page.locator(`[data-list-id="${listId}"]`);
+        await expect(newListNavItem).toBeVisible();
 
         const listExistsResponse = await request.get(`/list/${listId}`);
 

--- a/e2e/lists/delete-list.spec.ts
+++ b/e2e/lists/delete-list.spec.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 test.describe('a user can delete a list', () => {
     let listName: string;
+    let listId: string;
 
     test.beforeEach(async ({ page, isMobile }) => {
         test.skip(isMobile, 'This feature is desktop only');
@@ -25,6 +26,8 @@ test.describe('a user can delete a list', () => {
         ]);
 
         expect(createResponse.status()).toBeLessThan(400);
+        const created = await createResponse.json();
+        listId = created.id;
     });
 
     test('using the settings menu', async ({ page, request }) => {
@@ -32,9 +35,6 @@ test.describe('a user can delete a list', () => {
 
         const newListNavItem = page.locator(`[data-test-id="${listName}"]`);
         await expect(newListNavItem).toBeVisible();
-
-        const href = await newListNavItem.getAttribute('href');
-        const listId = href?.split('/').pop();
 
         expect(listId).toBeTruthy();
 
@@ -45,8 +45,14 @@ test.describe('a user can delete a list', () => {
         const settingsButton = page.locator(`[data-testid="setting-button-${listId}"]`);
         await settingsButton.click();
 
-        const deleteMenuItem = page.locator(`[data-test-id="delete-list"]`);
+        // Opens a context menu with a "Delete" item; selecting it reveals a
+        // confirmation dialog with the actual delete action.
+        const deleteMenuItem = page.getByRole('button', { name: 'Delete', exact: true });
         await expect(deleteMenuItem).toBeVisible();
+        await deleteMenuItem.click();
+
+        const confirmDeleteButton = page.getByTestId('delete-list');
+        await expect(confirmDeleteButton).toBeVisible();
 
         await Promise.all([
             page.waitForResponse((r) => {
@@ -58,7 +64,7 @@ test.describe('a user can delete a list', () => {
                 }
                 return isDelete;
             }),
-            deleteMenuItem.click(),
+            confirmDeleteButton.click(),
         ]);
 
         await page.waitForLoadState('networkidle');

--- a/e2e/lists/settings-button-navigation.spec.ts
+++ b/e2e/lists/settings-button-navigation.spec.ts
@@ -47,9 +47,11 @@ test.describe('list settings button prevents navigation', () => {
         // Wait a bit to see if navigation occurs
         await page.waitForTimeout(500);
 
-        // Verify the menu is open (Delete List option should be visible)
-        const deleteMenuItem = page.locator('[data-test-id="delete-list"]');
+        // Verify the menu is open (Delete option should be visible) and that
+        // clicking the settings button did not navigate away from the homepage
+        const deleteMenuItem = page.getByRole('button', { name: 'Delete', exact: true });
         await expect(deleteMenuItem).toBeVisible();
+        expect(page.url()).not.toMatch(/\/list\//);
     });
 
     test('clicking list item (not settings button) navigates to list page', async ({
@@ -88,11 +90,8 @@ test.describe('list settings button prevents navigation', () => {
         const newListNavItem = await page.locator(`[data-test-id="${listName}"]`);
         await expect(newListNavItem).toBeVisible();
 
-        // Get the list item title (not the settings button)
-        const listItemTitle = newListNavItem.locator('..').locator('.v-list-item-title').first();
-
-        // Click on the list item title (not the settings button)
-        await listItemTitle.click();
+        // Click on the list row itself (not the settings button)
+        await newListNavItem.click();
 
         // Wait for navigation to occur
         await page.waitForURL(/\/list\//, { timeout: 5000 });

--- a/e2e/lists/settings-button-navigation.spec.ts
+++ b/e2e/lists/settings-button-navigation.spec.ts
@@ -49,7 +49,7 @@ test.describe('list settings button prevents navigation', () => {
 
         // Verify the menu is open (Delete option should be visible) and that
         // clicking the settings button did not navigate away from the homepage
-        const deleteMenuItem = page.getByRole('button', { name: 'Delete', exact: true });
+        const deleteMenuItem = page.getByTestId('delete-list-menu-item');
         await expect(deleteMenuItem).toBeVisible();
         expect(page.url()).not.toMatch(/\/list\//);
     });

--- a/e2e/lists/settings-button-navigation.spec.ts
+++ b/e2e/lists/settings-button-navigation.spec.ts
@@ -35,8 +35,10 @@ test.describe('list settings button prevents navigation', () => {
 
         await page.waitForTimeout(500);
 
-        // Verify the list was created and is visible
-        const newListNavItem = await page.locator(`[data-test-id="${listName}"]`);
+        // Verify the list was created and is visible. Select by list id (not
+        // the user-entered name) since names can contain characters that are
+        // unsafe to interpolate into a CSS selector.
+        const newListNavItem = await page.locator(`[data-list-id="${listId}"]`);
         await expect(newListNavItem).toBeVisible();
 
         await page.waitForTimeout(500);
@@ -78,16 +80,20 @@ test.describe('list settings button prevents navigation', () => {
 
         const newListInput = await page.getByRole('textbox', { name: 'New List' });
         await newListInput.type(listName);
-        const createRequestPromise = page.waitForRequest(
-            request => request.url().includes('/api/list') && request.method() === 'POST',
+        const createResponsePromise = page.waitForResponse(
+            response =>
+                response.url().includes('/api/list') && response.request().method() === 'POST',
         );
         await page.keyboard.press('Enter');
-        await createRequestPromise;
+        const createResponse = await createResponsePromise;
+        const { id: listId } = await createResponse.json();
 
         await page.waitForTimeout(500);
 
-        // Verify the list was created and is visible
-        const newListNavItem = await page.locator(`[data-test-id="${listName}"]`);
+        // Verify the list was created and is visible. Select by list id (not
+        // the user-entered name) since names can contain characters that are
+        // unsafe to interpolate into a CSS selector.
+        const newListNavItem = await page.locator(`[data-list-id="${listId}"]`);
         await expect(newListNavItem).toBeVisible();
 
         // Click on the list row itself (not the settings button)

--- a/e2e/settings/settings-page.spec.ts
+++ b/e2e/settings/settings-page.spec.ts
@@ -1,11 +1,13 @@
 import { test, expect } from '../fixtures/index';
 
 test.describe('Settings page', () => {
-    test.beforeEach(async ({ request }) => {
+    test.beforeEach(async ({ request, isMobile }) => {
+        test.skip(isMobile, 'Settings sections are desktop only');
         await request.put('/api/settings', { data: { statuses: [] } });
     });
 
-    test.afterEach(async ({ request }) => {
+    test.afterEach(async ({ request, isMobile }) => {
+        test.skip(isMobile, 'Settings sections are desktop only');
         await request.put('/api/settings', { data: { statuses: [] } });
     });
 
@@ -13,27 +15,29 @@ test.describe('Settings page', () => {
         await page.goto('/settings');
         await page.waitForLoadState('networkidle');
 
-        await expect(page.getByText('Statuses', { exact: false })).toBeVisible();
+        // The settings sidebar links to each section - "Statuses" is now
+        // labelled "Workflow" but still governs status configuration.
+        await expect(page.getByText('Workflow', { exact: false })).toBeVisible();
         await expect(page.getByText('Integrations', { exact: false })).toBeVisible();
         await expect(page.getByText('Account', { exact: false })).toBeVisible();
     });
 
     test('shows GitHub Integration item', async ({ page }) => {
-        await page.goto('/settings');
+        await page.goto('/settings/integrations');
         await page.waitForLoadState('networkidle');
 
-        await expect(page.getByText('GitHub Integration')).toBeVisible();
+        await expect(page.getByText('GitHub')).toBeVisible();
     });
 
     test('shows Sign Out button', async ({ page }) => {
-        await page.goto('/settings');
+        await page.goto('/settings/account');
         await page.waitForLoadState('networkidle');
 
-        await expect(page.getByText('Sign Out')).toBeVisible();
+        await expect(page.getByText('Sign out')).toBeVisible();
     });
 
     test('can add a new status and save it', async ({ page }) => {
-        await page.goto('/settings');
+        await page.goto('/settings/workflow');
         await page.waitForLoadState('networkidle');
 
         await page.getByRole('button', { name: /add status/i }).click();
@@ -66,13 +70,15 @@ test.describe('Settings page', () => {
             },
         });
 
-        await page.goto('/settings');
+        await page.goto('/settings/workflow');
         await page.waitForLoadState('networkidle');
 
-        await expect(page.getByText('Test Status')).toBeVisible();
+        const statusRow = page.locator('.status-row').filter({ hasText: 'Test Status' });
+        await expect(statusRow).toBeVisible();
 
-        await page.locator('.v-main button:has(.mdi-dots-vertical)').first().click();
-        await page.getByText('Delete').click();
+        // The delete button is only visible while its row is hovered.
+        await statusRow.hover();
+        await statusRow.locator('.status-row__delete').click();
 
         await expect(page.getByText('Test Status')).not.toBeVisible();
     });

--- a/e2e/todos/new/new-test.spec.ts
+++ b/e2e/todos/new/new-test.spec.ts
@@ -29,7 +29,9 @@ test.describe('Create Todo', () => {
         const todoName = `Todo ${testId}`;
         await newTodoInput.fill(todoName);
 
+        const responsePromise = page.waitForResponse('**/api/todo');
         await newTodoInput.press('Enter');
+        await responsePromise;
 
         await page.reload();
         await page.waitForLoadState('networkidle');

--- a/e2e/todos/new/new-test.spec.ts
+++ b/e2e/todos/new/new-test.spec.ts
@@ -50,9 +50,7 @@ test.describe('Create Todo', () => {
         await newTodoInput.fill(`Todo ${uuidv4()}`);
         await newTodoInput.press('Enter');
         await page.waitForLoadState('networkidle');
-        await page.getByTestId('list-type-select').click();
-        await page.getByRole('option', { name: 'table' }).click();
-        await page.waitForLoadState('networkidle');
+        await page.getByRole('button', { name: 'Table' }).click();
         await page.getByRole('button', { name: 'Add Todo' }).click();
 
         const todoName = `Todo ${uuidv4()}`;


### PR DESCRIPTION
The sidebar and settings redesign (a54bacb, a4ada87, faf7f75, 319f53c)
dropped test hooks and changed routes/markup without updating e2e
coverage, which the Playwright CI job has been failing on since:

- App/Nav/Items.vue lost the `new-list-button` testid on the "new list"
  button and never carried a way to look up a created list row by name,
  so create-list/delete-list/settings-button-navigation tests couldn't
  find their elements.
- The list detail page's "Add a task" input lost its `new-todo-input`
  testid entirely, breaking todo creation in new-test.spec.ts.
- Settings moved from a single `/settings` page to `/settings/workflow`,
  `/settings/integrations`, `/settings/account` sub-routes, and "Sign
  out" moved out of Settings into the main nav's account popover;
  settings-page.spec.ts still pointed at the old single-page layout and
  text. Settings currently renders nothing on mobile, so those tests are
  now desktop-only like the rest of the list-management suite.
- create-todo-dialog-persists.spec.ts (added by the last PR) matched
  `new-todo-input` unscoped, which is ambiguous on the homepage since
  it also renders an inline add-todo field with the same test id.

Added back data-testid="new-list-button" and a per-row
data-test-id/data-list-id on App/Nav/Items.vue, and
data-testid="new-todo-input" on the list page's add-task bar, then
updated the affected e2e specs to match the current routes/markup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability with more precise element targeting and confirmation checks.
  * Updated navigation, list deletion, task creation, workflow, settings, and table-view tests to reflect current UI behavior.
  * Added mobile-aware handling for settings tests and aligned assertions with updated labels and routes.
* **Accessibility & Testability**
  * Added targeted attributes to list controls, list rows, and task entry fields for consistent automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->