### PR TITLE
Fix date picker calendar rendering behind the new-todo dialog on mobile

### DIFF
--- a/app/components/App/DueDate.vue
+++ b/app/components/App/DueDate.vue
@@ -455,7 +455,7 @@ onUnmounted(() => {
 /* ── Popover panel ────────────────────────────────────────────────────────── */
 .due-popover {
   position: fixed;
-  z-index: 2000;
+  z-index: 3000;
   width: 300px;
   background: #ffffff;
   border: 1px solid rgba(113, 124, 130, 0.16);


### PR DESCRIPTION
The AppDueDate popover was hardcoded to z-index: 2000, the same
default z-index Vuetify assigns to v-dialog. Creating a todo on
mobile opens the todo form inside a v-dialog, so the popover tied
with the dialog's stacking context and could render behind it.
Desktop wasn't affected since the dashboard renders the date field
outside any dialog.