### PR TITLE
Add DB schema for Vercel integration

### DIFF
--- a/supabase/migrations/20260719000000_add_vercel_integration.sql
+++ b/supabase/migrations/20260719000000_add_vercel_integration.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "public"."Todos" ADD COLUMN vercel_project_id text;
+ALTER TABLE "public"."Todos" ADD COLUMN vercel_deployment_url text;
+ALTER TABLE "public"."Todos" ADD COLUMN vercel_deployment_status text;
+
+ALTER TABLE "public"."Users" ADD COLUMN vercel_access_token text;
+ALTER TABLE "public"."Users" ADD COLUMN vercel_team_id text;
+ALTER TABLE "public"."Users" ADD COLUMN vercel_webhook_subscriptions jsonb;

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -69,6 +69,9 @@ export type Database = {
                     type: string | null;
                     updated_at: string | null;
                     user_id: string | null;
+                    vercel_deployment_status: string | null;
+                    vercel_deployment_url: string | null;
+                    vercel_project_id: string | null;
                 };
                 Insert: {
                     attachments?: Json | null;
@@ -94,6 +97,9 @@ export type Database = {
                     type?: string | null;
                     updated_at?: string | null;
                     user_id?: string | null;
+                    vercel_deployment_status?: string | null;
+                    vercel_deployment_url?: string | null;
+                    vercel_project_id?: string | null;
                 };
                 Update: {
                     attachments?: Json | null;
@@ -119,6 +125,9 @@ export type Database = {
                     type?: string | null;
                     updated_at?: string | null;
                     user_id?: string | null;
+                    vercel_deployment_status?: string | null;
+                    vercel_deployment_url?: string | null;
+                    vercel_project_id?: string | null;
                 };
                 Relationships: [
                     {
@@ -179,6 +188,9 @@ export type Database = {
                     push_subscriptions: Json | null;
                     statuses: Json | null;
                     username: string | null;
+                    vercel_access_token: string | null;
+                    vercel_team_id: string | null;
+                    vercel_webhook_subscriptions: Json | null;
                 };
                 Insert: {
                     github_installation_id?: number | null;
@@ -188,6 +200,9 @@ export type Database = {
                     push_subscriptions?: Json | null;
                     statuses?: Json | null;
                     username?: string | null;
+                    vercel_access_token?: string | null;
+                    vercel_team_id?: string | null;
+                    vercel_webhook_subscriptions?: Json | null;
                 };
                 Update: {
                     github_installation_id?: number | null;
@@ -197,6 +212,9 @@ export type Database = {
                     push_subscriptions?: Json | null;
                     statuses?: Json | null;
                     username?: string | null;
+                    vercel_access_token?: string | null;
+                    vercel_team_id?: string | null;
+                    vercel_webhook_subscriptions?: Json | null;
                 };
                 Relationships: [];
             };

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -240,37 +240,37 @@ type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, 'public'>]
 
 export type Tables<
     DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
-    | { schema: keyof DatabaseWithoutInternals },
+        | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+        | { schema: keyof DatabaseWithoutInternals },
     TableName extends DefaultSchemaTableNameOrOptions extends {
         schema: keyof DatabaseWithoutInternals;
     }
-        ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
-            & DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
+        ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+              DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
         : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
 }
-    ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
-        & DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
+    ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+          DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
+          Row: infer R;
+      }
+        ? R
+        : never
+    : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] &
+            DefaultSchema['Views'])
+      ? (DefaultSchema['Tables'] &
+            DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
             Row: infer R;
         }
-            ? R
-            : never
-    : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables']
-        & DefaultSchema['Views'])
-        ? (DefaultSchema['Tables']
-            & DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
-                Row: infer R;
-            }
-                ? R
-                : never
-        : never;
+          ? R
+          : never
+      : never;
 
 export type TablesInsert<
     DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
-    | { schema: keyof DatabaseWithoutInternals },
+        | keyof DefaultSchema['Tables']
+        | { schema: keyof DatabaseWithoutInternals },
     TableName extends DefaultSchemaTableNameOrOptions extends {
         schema: keyof DatabaseWithoutInternals;
     }
@@ -280,22 +280,22 @@ export type TablesInsert<
     schema: keyof DatabaseWithoutInternals;
 }
     ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
-        Insert: infer I;
-    }
+          Insert: infer I;
+      }
         ? I
         : never
     : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-        ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+      ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
             Insert: infer I;
         }
-            ? I
-            : never
-        : never;
+          ? I
+          : never
+      : never;
 
 export type TablesUpdate<
     DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
-    | { schema: keyof DatabaseWithoutInternals },
+        | keyof DefaultSchema['Tables']
+        | { schema: keyof DatabaseWithoutInternals },
     TableName extends DefaultSchemaTableNameOrOptions extends {
         schema: keyof DatabaseWithoutInternals;
     }
@@ -305,22 +305,22 @@ export type TablesUpdate<
     schema: keyof DatabaseWithoutInternals;
 }
     ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
-        Update: infer U;
-    }
+          Update: infer U;
+      }
         ? U
         : never
     : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-        ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+      ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
             Update: infer U;
         }
-            ? U
-            : never
-        : never;
+          ? U
+          : never
+      : never;
 
 export type Enums<
     DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema['Enums']
-    | { schema: keyof DatabaseWithoutInternals },
+        | keyof DefaultSchema['Enums']
+        | { schema: keyof DatabaseWithoutInternals },
     EnumName extends DefaultSchemaEnumNameOrOptions extends {
         schema: keyof DatabaseWithoutInternals;
     }
@@ -331,13 +331,13 @@ export type Enums<
 }
     ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
     : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
-        ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
-        : never;
+      ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
+      : never;
 
 export type CompositeTypes<
     PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema['CompositeTypes']
-    | { schema: keyof DatabaseWithoutInternals },
+        | keyof DefaultSchema['CompositeTypes']
+        | { schema: keyof DatabaseWithoutInternals },
     CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
         schema: keyof DatabaseWithoutInternals;
     }
@@ -348,8 +348,8 @@ export type CompositeTypes<
 }
     ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
     : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
-        ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
-        : never;
+      ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+      : never;
 
 export const Constants = {
     public: {


### PR DESCRIPTION
Adds vercel_project_id, vercel_deployment_url, and vercel_deployment_status
columns to Todos, and vercel_access_token, vercel_team_id, and
vercel_webhook_subscriptions to Users, mirroring the existing GitHub
integration's schema. Lays the groundwork for linking a todo to its
latest Vercel deployment (tickup task #4741).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EPoBnJowurSJQ7fLmFbPJk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting accounts with Vercel integrations.
  * Projects can now store Vercel project details, deployment URLs, and deployment status.
  * Vercel access, team, and webhook information can now be securely managed for connected accounts.
  * This enables improved tracking and management of deployments associated with projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->