### PR TITLE
Vercel connect/disconnect MCP tools + API

### DIFF
--- a/app/composables/hasVercel.ts
+++ b/app/composables/hasVercel.ts
@@ -1,0 +1,3 @@
+export const useHasVercel = async () => {
+    return await $fetch('/api/vercel/check');
+};

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -64,6 +64,11 @@ export default defineNuxtConfig({
                 clientSecret: process.env.GITHUB_CLIENT_SECRET,
                 webhookSecret: process.env.GITHUB_WEBHOOK_SECRET,
             },
+            vercel: {
+                clientId: process.env.VERCEL_INTEGRATION_CLIENT_ID,
+                clientSecret: process.env.VERCEL_INTEGRATION_CLIENT_SECRET,
+                redirectUri: process.env.VERCEL_INTEGRATION_REDIRECT_URI,
+            },
         },
 
         public: {
@@ -245,7 +250,7 @@ export default defineNuxtConfig({
     supabase: {
         redirectOptions: {
             login: '/login',
-            
+
             callback: '/confirm',
             include: undefined,
             exclude: ['/oauth/consent'],

--- a/server/api/vercel/check.ts
+++ b/server/api/vercel/check.ts
@@ -1,0 +1,18 @@
+import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server';
+
+export default defineEventHandler(async (event) => {
+    const user = await serverSupabaseUser(event);
+
+    if (!user) {
+        return false;
+    }
+
+    const supabase = await serverSupabaseClient(event);
+    const { data } = await supabase
+        .from('Users')
+        .select('vercel_access_token')
+        .eq('id', user.sub)
+        .single();
+
+    return !!data?.vercel_access_token;
+});

--- a/server/api/vercel/connect.post.ts
+++ b/server/api/vercel/connect.post.ts
@@ -1,0 +1,54 @@
+import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server';
+
+export default defineEventHandler(async (event) => {
+    const user = await serverSupabaseUser(event);
+    if (!user) {
+        throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
+    }
+
+    const body = await readBody(event);
+    const code = body.code;
+
+    if (!code) {
+        throw createError({ statusCode: 400, statusMessage: 'Missing code' });
+    }
+
+    const config = useRuntimeConfig();
+
+    const tokenRes = await fetch('https://api.vercel.com/v2/oauth/access_token', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+            client_id: config.vercel.clientId,
+            client_secret: config.vercel.clientSecret,
+            code,
+            redirect_uri: config.vercel.redirectUri,
+        }),
+    });
+    const tokenData = await tokenRes.json();
+
+    if (!tokenData.access_token) {
+        throw createError({
+            statusCode: 502,
+            statusMessage: tokenData.error_description || 'Failed to exchange Vercel OAuth code',
+        });
+    }
+
+    const supabase = await serverSupabaseClient(event);
+
+    const updateData: Record<string, unknown> = {
+        id: user.id,
+        vercel_access_token: tokenData.access_token,
+    };
+    if (tokenData.team_id) {
+        updateData.vercel_team_id = tokenData.team_id;
+    }
+
+    const { error } = await supabase.from('Users').upsert(updateData);
+
+    if (error) {
+        throw createError({ statusCode: 500, statusMessage: error.message });
+    }
+
+    return { success: true };
+});

--- a/server/api/vercel/disconnect.post.ts
+++ b/server/api/vercel/disconnect.post.ts
@@ -1,0 +1,21 @@
+import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server';
+
+export default defineEventHandler(async (event) => {
+    const user = await serverSupabaseUser(event);
+    if (!user) {
+        throw createError({ statusCode: 401, statusMessage: 'Unauthorized' });
+    }
+
+    const supabase = await serverSupabaseClient(event);
+
+    const { error } = await supabase
+        .from('Users')
+        .update({ vercel_access_token: null, vercel_team_id: null })
+        .eq('id', user.sub);
+
+    if (error) {
+        throw createError({ statusCode: 500, statusMessage: error.message });
+    }
+
+    return { success: true };
+});

--- a/server/mcp/tools/vercel/connect-vercel.ts
+++ b/server/mcp/tools/vercel/connect-vercel.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import { callApi } from '../../utils/api';
+
+export default defineMcpTool({
+    name: 'connect_vercel',
+    description:
+        'Exchange a Vercel OAuth code and save the resulting access token for the signed-in user',
+    inputSchema: {
+        code: z.string().describe('OAuth code from the Vercel Integration install flow'),
+    },
+    handler: async ({ code }) => {
+        return await callApi('/api/vercel/connect', {
+            method: 'POST',
+            body: { code },
+        });
+    },
+});

--- a/server/mcp/tools/vercel/disconnect-vercel.ts
+++ b/server/mcp/tools/vercel/disconnect-vercel.ts
@@ -1,0 +1,11 @@
+import { callApi } from '../../utils/api';
+
+export default defineMcpTool({
+    name: 'disconnect_vercel',
+    description: "Disconnect the signed-in user's Vercel integration",
+    annotations: { destructiveHint: true },
+    inputSchema: {},
+    handler: async () => {
+        return await callApi('/api/vercel/disconnect', { method: 'POST' });
+    },
+});

--- a/test/unit/mcp/connect-vercel.test.ts
+++ b/test/unit/mcp/connect-vercel.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect } from 'vitest';
+import { mcpTest } from '../fixtures/mcp';
+
+describe('connect_vercel MCP tool', () => {
+    mcpTest('is registered with a code input', async ({ client }) => {
+        const { tools } = await client.listTools();
+        const tool = tools.find(({ name }) => name === 'connect_vercel');
+
+        expect(tool).toBeDefined();
+        expect(tool?.description?.toLowerCase()).toContain('vercel');
+        expect(tool?.inputSchema.required).toContain('code');
+    });
+
+    mcpTest('rejects a call missing the required code', async ({ client }) => {
+        const result = await client.callTool({
+            name: 'connect_vercel',
+            arguments: {},
+        });
+
+        expect(result.isError).toBeTruthy();
+    });
+});

--- a/test/unit/mcp/disconnect-vercel.test.ts
+++ b/test/unit/mcp/disconnect-vercel.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect } from 'vitest';
+import { mcpTest } from '../fixtures/mcp';
+
+function parseContent(result: unknown): Record<string, unknown> {
+    const contentArray = (result as Record<string, unknown>).content as {
+        type: string;
+        text?: string;
+    }[];
+    const textContent = contentArray.find(({ type }) => type === 'text');
+    if (!textContent?.text) throw new Error('Text content expected');
+    return JSON.parse(textContent.text);
+}
+
+describe('disconnect_vercel MCP tool', () => {
+    mcpTest('is registered with no required input', async ({ client }) => {
+        const { tools } = await client.listTools();
+        const tool = tools.find(({ name }) => name === 'disconnect_vercel');
+
+        expect(tool).toBeDefined();
+        expect(tool?.description?.toLowerCase()).toContain('vercel');
+    });
+
+    mcpTest('clears the stored Vercel token for the signed-in user', async ({ client }) => {
+        const result = await client.callTool({
+            name: 'disconnect_vercel',
+            arguments: {},
+        });
+
+        expect(parseContent(result)).toMatchObject({ success: true });
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `connect_vercel`/`disconnect_vercel` MCP tools (thin proxies, mirroring `connect-github.ts`/`disconnect-github.ts`)
- Adds `/api/vercel/connect` (exchanges an OAuth code for an access token via Vercel's `/v2/oauth/access_token`), `/api/vercel/disconnect`, and `/api/vercel/check` Nitro routes
- Adds a `useHasVercel()` composable (mirrors `useHasGithub()`)
- Stores the token directly on `Users.vercel_access_token`/`vercel_team_id` — mirrors GitHub's real `github_installation_id`-on-`Users` pattern, not the unused `user_integrations` table
- Adds `VERCEL_INTEGRATION_CLIENT_ID`/`VERCEL_INTEGRATION_CLIENT_SECRET`/`VERCEL_INTEGRATION_REDIRECT_URI` runtime config (distinct from Vercel's own platform-injected `VERCEL_URL`/`VERCEL_ENV`)
- Adds MCP tool test suites for both tools

Closes tickup task #4742.

## Test plan
- [x] `pnpm lint` / `prettier --check` clean on all new files
- [x] `tsc --noEmit` shows no new errors beyond the same pre-existing `config.github.clientId`-style `unknown` typing gap already present in `server/api/github/connect.post.ts`
- [ ] `pnpm test:mcp` — new tests require live Supabase credentials + running server (CI-only in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EPoBnJowurSJQ7fLmFbPJk)_