### PR TITLE
MCP tool: list_vercel_projects

### DIFF
--- a/server/api/vercel/projects.get.ts
+++ b/server/api/vercel/projects.get.ts
@@ -1,0 +1,58 @@
+import { defineEventHandler, createError } from 'h3';
+import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server';
+import type { Database } from '~~/types/database.types';
+
+export default defineEventHandler(async (event) => {
+    const user = await serverSupabaseUser(event);
+    if (!user) {
+        throw createError({ statusCode: 401, message: 'Unauthorized' });
+    }
+
+    const supabase = await serverSupabaseClient<Database>(event);
+    const { data: userData } = await supabase
+        .from('Users')
+        .select('vercel_access_token, vercel_team_id')
+        .eq('id', user.sub)
+        .single();
+
+    if (!userData?.vercel_access_token) {
+        throw createError({ statusCode: 403, message: 'Vercel integration not connected.' });
+    }
+
+    const query = userData.vercel_team_id
+        ? `?teamId=${encodeURIComponent(userData.vercel_team_id)}`
+        : '';
+
+    try {
+        const res = await fetch(`https://api.vercel.com/v9/projects${query}`, {
+            headers: { Authorization: `Bearer ${userData.vercel_access_token}` },
+        });
+        const data = await res.json();
+
+        if (!res.ok) {
+            throw new Error(data.error?.message || 'Failed to list projects');
+        }
+
+        return {
+            projects: (data.projects || []).map((project: Record<string, unknown>) => ({
+                id: project.id,
+                name: project.name,
+                framework: project.framework,
+                link: project.link
+                    ? {
+                          type: (project.link as Record<string, unknown>).type,
+                          org: (project.link as Record<string, unknown>).org,
+                          repo: (project.link as Record<string, unknown>).repo,
+                      }
+                    : null,
+                updatedAt: project.updatedAt,
+            })),
+        };
+    } catch (error: any) {
+        console.error('Error listing Vercel projects:', error);
+        throw createError({
+            statusCode: error.status || 500,
+            message: error.message || 'Failed to list projects',
+        });
+    }
+});

--- a/server/mcp/tools/vercel/list-vercel-projects.ts
+++ b/server/mcp/tools/vercel/list-vercel-projects.ts
@@ -1,0 +1,10 @@
+import { callApi } from '../../utils/api';
+
+export default defineMcpTool({
+    name: 'list_vercel_projects',
+    description: "List Vercel projects accessible to the signed-in user's connected Vercel account",
+    inputSchema: {},
+    handler: async () => {
+        return await callApi('/api/vercel/projects');
+    },
+});

--- a/test/unit/mcp/list-vercel-projects.test.ts
+++ b/test/unit/mcp/list-vercel-projects.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect } from 'vitest';
+import { mcpTest } from '../fixtures/mcp';
+
+describe('list_vercel_projects MCP tool', () => {
+    mcpTest('is registered with no required input', async ({ client }) => {
+        const { tools } = await client.listTools();
+        const tool = tools.find(({ name }) => name === 'list_vercel_projects');
+
+        expect(tool).toBeDefined();
+        expect(tool?.description?.toLowerCase()).toContain('vercel');
+    });
+
+    mcpTest('returns an error when Vercel is not connected', async ({ client }) => {
+        const result = await client.callTool({
+            name: 'list_vercel_projects',
+            arguments: {},
+        });
+
+        const content = result.content as { type: string; text?: string }[];
+        const textContent = content.find(({ type }) => type === 'text');
+        expect(textContent?.text).toBeDefined();
+        expect(textContent!.text!.toLowerCase()).toMatch(/not connected|error/);
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `list_vercel_projects` MCP tool + `server/api/vercel/projects.get.ts` proxy route
- Mirrors `list_github_repos` / `list-github-branches.ts`'s thin-proxy pattern
- Requires the Vercel connection from #4742 (`vercel_access_token` on `Users`), so this PR is based on that branch rather than `vercel` directly — `vercel` itself is still at its original empty snapshot since #161/#162 haven't been merged yet.

## Test plan
- [ ] `pnpm test:mcp` — `list_vercel_projects` tool discovery + not-connected error path (test/unit/mcp/list-vercel-projects.test.ts)

Closes tickup task #4743.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EPoBnJowurSJQ7fLmFbPJk)_