### PR TITLE
MCP tool: get_vercel_deployment

### DIFF
--- a/server/api/vercel/deployment.get.ts
+++ b/server/api/vercel/deployment.get.ts
@@ -1,0 +1,68 @@
+import { defineEventHandler, createError, getQuery } from 'h3';
+import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server';
+import type { Database } from '~~/types/database.types';
+
+export default defineEventHandler(async (event) => {
+    const user = await serverSupabaseUser(event);
+    if (!user) {
+        throw createError({ statusCode: 401, message: 'Unauthorized' });
+    }
+
+    const supabase = await serverSupabaseClient<Database>(event);
+    const { data: userData } = await supabase
+        .from('Users')
+        .select('vercel_access_token, vercel_team_id')
+        .eq('id', user.sub)
+        .single();
+
+    if (!userData?.vercel_access_token) {
+        throw createError({ statusCode: 403, message: 'Vercel integration not connected.' });
+    }
+
+    const { projectId } = getQuery(event);
+    const safeProjectId = Array.isArray(projectId) ? projectId[0] : String(projectId ?? '');
+
+    if (!safeProjectId) {
+        throw createError({ statusCode: 400, message: 'Missing projectId' });
+    }
+
+    const params = new URLSearchParams({
+        projectId: safeProjectId,
+        target: 'production',
+        limit: '1',
+    });
+    if (userData.vercel_team_id) {
+        params.set('teamId', userData.vercel_team_id);
+    }
+
+    let data: any;
+    try {
+        const res = await fetch(`https://api.vercel.com/v6/deployments?${params.toString()}`, {
+            headers: { Authorization: `Bearer ${userData.vercel_access_token}` },
+        });
+        data = await res.json();
+
+        if (!res.ok) {
+            throw new Error(data.error?.message || 'Failed to fetch deployments');
+        }
+    } catch (error: any) {
+        console.error('Error fetching Vercel deployment:', error);
+        throw createError({
+            statusCode: error.status || 500,
+            message: error.message || 'Failed to fetch deployment',
+        });
+    }
+
+    const deployment = data.deployments?.[0];
+    if (!deployment) {
+        throw createError({ statusCode: 404, message: 'No deployments found for this project.' });
+    }
+
+    return {
+        id: deployment.uid,
+        url: `https://${deployment.url}`,
+        state: deployment.state,
+        readyState: deployment.readyState,
+        createdAt: deployment.createdAt || deployment.created,
+    };
+});

--- a/server/mcp/tools/vercel/get-vercel-deployment.ts
+++ b/server/mcp/tools/vercel/get-vercel-deployment.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+import { callApi } from '../../utils/api';
+
+export default defineMcpTool({
+    name: 'get_vercel_deployment',
+    description: 'Get the latest production deployment for a Vercel project',
+    inputSchema: {
+        projectId: z.string().describe('Vercel project ID'),
+    },
+    handler: async ({ projectId }) => {
+        return await callApi('/api/vercel/deployment', { query: { projectId } });
+    },
+});

--- a/test/unit/mcp/get-vercel-deployment.test.ts
+++ b/test/unit/mcp/get-vercel-deployment.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect } from 'vitest';
+import { mcpTest } from '../fixtures/mcp';
+
+describe('get_vercel_deployment MCP tool', () => {
+    mcpTest('is registered with a required projectId input', async ({ client }) => {
+        const { tools } = await client.listTools();
+        const tool = tools.find(({ name }) => name === 'get_vercel_deployment');
+
+        expect(tool).toBeDefined();
+        expect(tool?.description?.toLowerCase()).toContain('vercel');
+        expect(tool?.inputSchema.required).toContain('projectId');
+    });
+
+    mcpTest('returns an error when Vercel is not connected', async ({ client }) => {
+        const result = await client.callTool({
+            name: 'get_vercel_deployment',
+            arguments: { projectId: 'prj_test123' },
+        });
+
+        const content = result.content as { type: string; text?: string }[];
+        const textContent = content.find(({ type }) => type === 'text');
+        expect(textContent?.text).toBeDefined();
+        expect(textContent!.text!.toLowerCase()).toMatch(/not connected|error/);
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `get_vercel_deployment` MCP tool + `server/api/vercel/deployment.get.ts` proxy route
- Calls Vercel's `GET /v6/deployments?projectId=...&target=production&limit=1` to fetch the latest production deployment's URL and state
- This is the core lookup that resolves "the latest deployment" for the link-on-task feature (tickup task #4211's Vercel epic)
- Mirrors the `get_github_branch` / `branch.get.ts` query-param proxy pattern

## Test plan
- [ ] `pnpm test:mcp` — tool discovery + not-connected error path (test/unit/mcp/get-vercel-deployment.test.ts)

Closes tickup task #4744.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EPoBnJowurSJQ7fLmFbPJk)_