### PR TITLE
Link Vercel project/deployment to a todo

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,9 @@ declare global {
         githubRepo?: string;
         githubLink?: string;
         githubPrLink?: string;
+        vercelProjectId?: string;
+        vercelDeploymentUrl?: string;
+        vercelDeploymentStatus?: string;
         links?: {
             id?: string;
             title: string;


### PR DESCRIPTION
## Summary
- Adds `vercelProjectId`/`vercelDeploymentUrl`/`vercelDeploymentStatus` to the `Task` interface in `index.d.ts`
- No new API route needed: `PUT /api/todo/:id` (`server/api/todo/[_id].put.ts`) already accepts arbitrary camelCase fields and converts them via `objectToSnake` before writing to `Todos` — the exact same generic path GitHub branch linking uses (there's no dedicated `link.post.ts` for GitHub either). The `Todos.vercel_*` columns already exist from #4741.
- This unblocks a future `VercelButton.vue` (mirroring `GithubButton.vue`) to set `listsStore.currentTodo.vercelProjectId = ...` and call the existing `listStore.updateTodo()`, without a new backend endpoint.

Closes tickup task #4745.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EPoBnJowurSJQ7fLmFbPJk)_