### PR TITLE
Fix mobile settings page missing Integrations (and all other) sections

### DIFF
--- a/app/pages/(settings)/settings.vue
+++ b/app/pages/(settings)/settings.vue
@@ -90,9 +90,29 @@ onMounted(async () => {
         v-else
         class="settings-mobile"
     >
-        <h1 class="settings-mobile__title">
-            Settings
-        </h1>
+        <template v-if="route.path === '/settings'">
+            <h1 class="settings-mobile__title">
+                Settings
+            </h1>
+            <SettingsNav
+                :active-section="activeSection"
+                @navigate="activeSection = $event"
+            />
+        </template>
+
+        <template v-else>
+            <div class="settings-mobile__header">
+                <v-btn
+                    icon="mdi-arrow-left"
+                    variant="text"
+                    to="/settings"
+                />
+                <h1 class="settings-mobile__title text-capitalize">
+                    {{ route.path.split('/').pop() }}
+                </h1>
+            </div>
+            <NuxtPage />
+        </template>
     </div>
 </template>
 
@@ -235,6 +255,17 @@ onMounted(async () => {
   padding: 24px 20px 80px;
   background: var(--color-background, #f7f9fb);
   min-height: 100%;
+}
+
+.settings-mobile__header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin: -8px -8px 16px;
+}
+
+.settings-mobile__header .settings-mobile__title {
+  margin: 0;
 }
 
 .settings-mobile__title {


### PR DESCRIPTION
## Summary
- `app/pages/(settings)/settings.vue`'s mobile branch rendered only a static "Settings" `<h1>` — the desktop branch's sidebar nav (`<SettingsNav>`) and `<NuxtPage />` (which renders `/settings/workflow`, `/settings/integrations`, `/settings/account`) were both gated behind `v-if="mdAndUp"`, so none of the settings sections ever appeared on mobile, not just Integrations.
- Adds a mobile nav list at `/settings` (reusing the existing `<SettingsNav>` component so mobile and desktop share the same section list) and renders `<NuxtPage />` with a back button when a subsection is active.

## Test plan
- [ ] On mobile viewport, `/settings` shows a Workflow/Integrations/Account nav list
- [ ] Tapping "Integrations" navigates to `/settings/integrations` and shows the GitHub integration row (and any future Vercel row)
- [ ] Back button returns to the `/settings` nav list
- [ ] Desktop layout unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01EPoBnJowurSJQ7fLmFbPJk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the mobile settings navigation with contextual headers.
  - Added a back button and automatically generated page titles for nested settings pages.
  - Refined header spacing and alignment for a more consistent mobile layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->