### PR TITLE
Fix workbox StaleWhileRevalidate no-response error for list/todo routes

### DIFF
--- a/app/service-worker/sw.ts
+++ b/app/service-worker/sw.ts
@@ -14,6 +14,11 @@ registerRoute(
         url.pathname == '/' || url.pathname.startsWith('/list') || url.pathname.startsWith('/todo'),
     new StaleWhileRevalidate({
         cacheName: 'pages',
+        plugins: [
+            {
+                handlerDidError: async () => caches.match('/offline.html'),
+            },
+        ],
     }),
 );
 
@@ -23,11 +28,11 @@ registerRoute(
     ({ url }) => {
         const p = url.pathname;
         return (
-            p === '/api/todos'
-            || p === '/api/lists'
-            || p === '/api/list/todos'
-            || p.startsWith('/api/todo/')
-            || (p.startsWith('/api/list/') && p !== '/api/list/todos')
+            p === '/api/todos' ||
+            p === '/api/lists' ||
+            p === '/api/list/todos' ||
+            p.startsWith('/api/todo/') ||
+            (p.startsWith('/api/list/') && p !== '/api/list/todos')
         );
     },
     new NetworkFirst({
@@ -60,12 +65,10 @@ async function requestPersistentStorage() {
             const granted = await navigator.storage.persist();
             if (granted) {
                 console.log('Persistent storage granted!');
-            }
-            else {
+            } else {
                 console.log('Persistent storage not granted.');
             }
-        }
-        else {
+        } else {
             console.log('Storage is already persistent.');
         }
     }
@@ -90,8 +93,7 @@ self.addEventListener('push', (event: PushEvent) => {
     if (event.data) {
         try {
             data = event.data.json();
-        }
-        catch {
+        } catch {
             data = { body: event.data.text() };
         }
     }

--- a/e2e/app/service-worker/no-response-error.spec.ts
+++ b/e2e/app/service-worker/no-response-error.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '../../fixtures/index';
+import { v4 as uuidv4 } from 'uuid';
+
+test.describe('Service worker — StaleWhileRevalidate error handling', () => {
+    test('navigating to a list page does not throw no-response error', async ({
+        page,
+        listAPI,
+    }) => {
+        const list = await listAPI.new({ name: `SW test ${uuidv4()}`, listType: '' });
+
+        const pageErrors: string[] = [];
+        page.on('pageerror', (err) => pageErrors.push(err.message));
+
+        await page.goto(`/list/${list.id}`);
+        await page.waitForLoadState('networkidle');
+
+        // Clean up
+        await page.request.delete(`/api/list/${list.id}`);
+
+        const noResponseErrors = pageErrors.filter((e) => e.includes('no-response'));
+        expect(noResponseErrors).toHaveLength(0);
+    });
+
+    test('navigating to a todo page does not throw no-response error', async ({
+        page,
+        listAPI,
+        request,
+    }) => {
+        const list = await listAPI.new({ name: `SW test ${uuidv4()}`, listType: '' });
+        const todoRes = await request.post('/api/todo', {
+            data: { name: `SW todo ${uuidv4()}`, listId: list.id, status: 'Open' },
+        });
+        expect(todoRes.ok()).toBeTruthy();
+        const todo = await todoRes.json();
+
+        const pageErrors: string[] = [];
+        page.on('pageerror', (err) => pageErrors.push(err.message));
+
+        await page.goto(`/todo/${todo.id}`);
+        await page.waitForLoadState('networkidle');
+
+        // Clean up
+        await request.delete(`/api/todo/${todo.id}`);
+        await request.delete(`/api/list/${list.id}`);
+
+        const noResponseErrors = pageErrors.filter((e) => e.includes('no-response'));
+        expect(noResponseErrors).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Summary

- `sw.ts` used `StaleWhileRevalidate` for `/`, `/list/*`, `/todo/*` routes with no error fallback
- When cache is cold (first visit) and any network issue occurs, Workbox throws `no-response` as an unhandled promise rejection
- Added `handlerDidError` plugin returning `caches.match('/offline.html')` so failures degrade gracefully to the offline page instead of throwing

## Test plan

- [ ] Navigate to a list page in a browser with the service worker active
- [ ] Confirm no `Uncaught (in promise) no-response` errors in console
- [ ] Simulate offline (DevTools → Network → Offline) and navigate to `/list/[id]` — should show offline.html instead of error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added offline fallback support for precached pages, displaying the offline page when content cannot be retrieved.

- **Bug Fixes**
  - Improved resilience when processing push notification data that is not valid JSON.
  - Preserved consistent handling for todo and list API requests.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->