### PR TITLE
Fix recent todos update by excluding joined list field

### DIFF
--- a/e2e/api/homepage/update-recent-todo.spec.ts
+++ b/e2e/api/homepage/update-recent-todo.spec.ts
@@ -25,6 +25,9 @@ test.describe('Homepage - update todo from Recent section', () => {
         const todo = recentTodos.find(t => t.name === todoName);
         expect(todo).toBeTruthy();
         expect(todo.list).toBeTruthy();
+        // Raw Supabase relation key from `.select('*, Lists(id, name)')` must not
+        // leak - objectToSnake would turn it into `lists`, an unknown Todos column.
+        expect(todo.Lists).toBeUndefined();
 
         // Mimic the mobile homepage "Recent" checkbox flow: the full todo
         // object (including the joined `list` field, which is not a real

--- a/e2e/api/homepage/update-recent-todo.spec.ts
+++ b/e2e/api/homepage/update-recent-todo.spec.ts
@@ -22,7 +22,7 @@ test.describe('Homepage - update todo from Recent section', () => {
         // to each todo (server/api/todos.ts) for display purposes.
         const recentResponse = await request.get('/api/todos?recent=true');
         const recentTodos = await recentResponse.json();
-        const todo = recentTodos.find(t => t.name === todoName);
+        const todo = recentTodos.find((t) => t.name === todoName);
         expect(todo).toBeTruthy();
         expect(todo.list).toBeTruthy();
         // Raw Supabase relation key from `.select('*, Lists(id, name)')` must not

--- a/e2e/api/homepage/update-recent-todo.spec.ts
+++ b/e2e/api/homepage/update-recent-todo.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { v4 as uuidv4 } from 'uuid';
+import { createTodo } from '../helpers/todos';
+import { createList } from '../helpers/lists';
+
+test.describe('Homepage - update todo from Recent section', () => {
+    test('marking a recent todo done does not 500', async ({ request }) => {
+        const testId = uuidv4();
+
+        const list = await createList(request, {
+            name: `Test List ${testId}`,
+        });
+
+        const todoName = `Recent Todo ${testId}`;
+        await createTodo(request, {
+            name: todoName,
+            dueDate: new Date(),
+            listId: list.id,
+        });
+
+        // GET /api/todos?recent=true joins Lists and attaches a `list` object
+        // to each todo (server/api/todos.ts) for display purposes.
+        const recentResponse = await request.get('/api/todos?recent=true');
+        const recentTodos = await recentResponse.json();
+        const todo = recentTodos.find(t => t.name === todoName);
+        expect(todo).toBeTruthy();
+        expect(todo.list).toBeTruthy();
+
+        // Mimic the mobile homepage "Recent" checkbox flow: the full todo
+        // object (including the joined `list` field, which is not a real
+        // Todos column) is PUT back when the todo is marked done.
+        const updateResponse = await request.put(`/api/todo/${todo.id}`, {
+            data: { ...todo, status: 'Closed' },
+        });
+
+        expect(updateResponse.status()).toBe(200);
+        const updated = await updateResponse.json();
+        expect(updated.status).toBe('Closed');
+    });
+});

--- a/server/api/todo/[_id].put.ts
+++ b/server/api/todo/[_id].put.ts
@@ -6,6 +6,9 @@ export default defineEventHandler(async (event) => {
 
     delete body.subtasks;
     delete body.edit;
+    // Joined display-only field added by GET /api/todos?recent=true (server/api/todos.ts)
+    // - not a real Todos column, so Supabase rejects the update if it's sent back.
+    delete body.list;
 
     if (!event.context.params || !event.context.params._id) {
         throw createError({

--- a/server/api/todos.ts
+++ b/server/api/todos.ts
@@ -51,7 +51,7 @@ export default defineEventHandler(async (event) => {
                 return [];
             }
 
-            return (data || []).map(todo => ({
+            return (data || []).map(({ Lists, ...todo }) => ({
                 ...todo,
                 dueDate: todo.due_date,
                 completedDate: todo.completed_date,
@@ -62,7 +62,7 @@ export default defineEventHandler(async (event) => {
                 notificationSent: todo.notification_sent,
                 createdAt: todo.created_at,
                 updatedAt: todo.updated_at,
-                list: todo.Lists ? { id: todo.Lists.id, name: todo.Lists.name } : null,
+                list: Lists ? { id: Lists.id, name: Lists.name } : null,
             }));
         }
 

--- a/server/api/todos.ts
+++ b/server/api/todos.ts
@@ -1,4 +1,5 @@
 import { serverSupabaseClient } from '#supabase/server';
+import { objectToCamel } from 'ts-case-convert';
 
 export default defineEventHandler(async (event) => {
     try {
@@ -52,17 +53,8 @@ export default defineEventHandler(async (event) => {
             }
 
             return (data || []).map(({ Lists, ...todo }) => ({
-                ...todo,
-                dueDate: todo.due_date,
-                completedDate: todo.completed_date,
-                userId: todo.user_id,
-                listId: todo.list_id,
-                githubBranchName: todo.github_branch_name,
-                notificationDateTime: todo.notification_date_time,
-                notificationSent: todo.notification_sent,
-                createdAt: todo.created_at,
-                updatedAt: todo.updated_at,
-                list: Lists ? { id: Lists.id, name: Lists.name } : null,
+                ...objectToCamel(todo),
+                list: Lists ? objectToCamel(Lists) : null,
             }));
         }
 

--- a/server/api/todos.ts
+++ b/server/api/todos.ts
@@ -24,7 +24,7 @@ export default defineEventHandler(async (event) => {
             }
 
             // Transform snake_case fields to camelCase
-            return (data || []).map(todo => ({
+            return (data || []).map((todo) => ({
                 ...todo,
                 dueDate: todo.due_date,
                 completedDate: todo.completed_date,
@@ -75,7 +75,7 @@ export default defineEventHandler(async (event) => {
             }
 
             // Transform snake_case fields to camelCase
-            return (data || []).map(todo => ({
+            return (data || []).map((todo) => ({
                 ...todo,
                 dueDate: todo.due_date,
                 completedDate: todo.completed_date,
@@ -97,7 +97,7 @@ export default defineEventHandler(async (event) => {
         }
 
         // Transform snake_case fields to camelCase
-        return (data || []).map(todo => ({
+        return (data || []).map((todo) => ({
             ...todo,
             dueDate: todo.due_date,
             completedDate: todo.completed_date,
@@ -109,8 +109,7 @@ export default defineEventHandler(async (event) => {
             createdAt: todo.created_at,
             updatedAt: todo.updated_at,
         }));
-    }
-    catch (error) {
+    } catch (error) {
         console.error('Error fetching todos:', error);
         return [];
     }


### PR DESCRIPTION
## Summary
Fixes a 500 error when updating a todo from the homepage "Recent" section. The issue occurs because the `GET /api/todos?recent=true` endpoint joins the `Lists` table and transforms it into a `list` display field, but this joined field was being sent back to the `PUT /api/todo/:id` endpoint, causing Supabase to reject the update (since `list` is not a real Todos column).

## Changes
- **server/api/todos.ts**: Destructure and exclude the raw `Lists` field from the response mapping, preventing the Supabase relation key from leaking into the API response. The `list` field is still properly constructed from the `Lists` data for display purposes.
- **server/api/todo/[_id].put.ts**: Delete the `list` field from the request body before updating, ensuring only real Todos columns are sent to Supabase.
- **e2e/api/homepage/update-recent-todo.spec.ts** (new): Add a regression test that verifies:
  - Recent todos are fetched with the joined `list` field
  - The raw `Lists` field does not leak into the response
  - Updating a recent todo with the full object (including `list`) succeeds with a 200 response

## Implementation Details
The fix uses destructuring (`{ Lists, ...todo }`) to cleanly separate the Supabase relation from the transformed todo object, ensuring the raw relation key never reaches the client while preserving the display-friendly `list` field.

https://claude.ai/code/session_01Ah8Ug1gHHUPiCdrRzVX7oF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Recent section so todos display their associated list correctly.
  * Fixed updating recent todos, including marking them complete from mobile views.
  * Prevented display-only list information from interfering with todo updates.

* **Tests**
  * Added coverage for retrieving and updating recent todos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->