### PR TITLE
VercelButton.vue UI + subcomponents

### DIFF
--- a/app/components/Vercel/Button.vue
+++ b/app/components/Vercel/Button.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+const { todo } = defineProps<{ todo: Task }>();
+const listStore = useListsStore();
+
+const activatorColor = computed(() => {
+    const state = listStore.currentTodo.vercelDeploymentStatus?.toLowerCase();
+    if (state === 'ready') return 'green';
+    if (state === 'error' || state === 'canceled') return 'red';
+    if (state === 'building' || state === 'queued' || state === 'initializing') return 'orange';
+    return undefined;
+});
+</script>
+
+<template>
+    <v-menu :close-on-content-click="false" elevation="0">
+        <template #activator="{ props }">
+            <v-btn v-bind="props" icon="mdi-triangle" :color="activatorColor" />
+        </template>
+        <v-list density="compact" elevation="1" class="rounded-xl pa-2">
+            <v-list-item slim>
+                <VercelDeploymentSelect />
+            </v-list-item>
+        </v-list>
+    </v-menu>
+</template>

--- a/app/components/Vercel/Deployment/Link.vue
+++ b/app/components/Vercel/Deployment/Link.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+const { notify } = useNotification();
+const listStore = useListsStore();
+const selectedProject = useState<{ id: string; name: string } | null>('vercelProject', () => null);
+const loading = ref(false);
+
+async function linkProject() {
+    if (!selectedProject.value) return;
+    loading.value = true;
+    try {
+        const deployment = await $fetch<{ url: string; state: string; readyState: string }>(
+            '/api/vercel/deployment',
+            { query: { projectId: selectedProject.value.id } },
+        );
+        listStore.currentTodo.vercelProjectId = selectedProject.value.id;
+        listStore.currentTodo.vercelDeploymentUrl = deployment.url;
+        listStore.currentTodo.vercelDeploymentStatus = deployment.readyState || deployment.state;
+        await listStore.updateTodo();
+        notify('Vercel project linked');
+    } catch {
+        notify('Failed to link Vercel project');
+    } finally {
+        loading.value = false;
+    }
+}
+</script>
+
+<template>
+    <v-btn
+        v-if="selectedProject"
+        :loading="loading"
+        icon="mdi-link"
+        variant="tonal"
+        size="x-small"
+        color="green"
+        @click="linkProject"
+    />
+</template>

--- a/app/components/Vercel/Deployment/Open.vue
+++ b/app/components/Vercel/Deployment/Open.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+const listStore = useListsStore();
+</script>
+
+<template>
+    <v-btn
+        v-if="listStore.currentTodo.vercelDeploymentUrl"
+        size="small"
+        icon="mdi-open-in-new"
+        :href="listStore.currentTodo.vercelDeploymentUrl"
+        target="_blank"
+    />
+</template>

--- a/app/components/Vercel/Deployment/Refresh.vue
+++ b/app/components/Vercel/Deployment/Refresh.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+const { notify } = useNotification();
+const listStore = useListsStore();
+const loading = ref(false);
+
+async function refreshDeployment() {
+    if (!listStore.currentTodo.vercelProjectId) return;
+    loading.value = true;
+    try {
+        const deployment = await $fetch<{ url: string; state: string; readyState: string }>(
+            '/api/vercel/deployment',
+            {
+                query: { projectId: listStore.currentTodo.vercelProjectId },
+            },
+        );
+        listStore.currentTodo.vercelDeploymentUrl = deployment.url;
+        listStore.currentTodo.vercelDeploymentStatus = deployment.readyState || deployment.state;
+        await listStore.updateTodo();
+        notify('Deployment status refreshed');
+    } catch {
+        notify('Failed to refresh deployment status');
+    } finally {
+        loading.value = false;
+    }
+}
+</script>
+
+<template>
+    <v-btn :loading="loading" icon="mdi-refresh" size="small" @click="refreshDeployment" />
+</template>

--- a/app/components/Vercel/Deployment/Select.vue
+++ b/app/components/Vercel/Deployment/Select.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+const listStore = useListsStore();
+const selectedProject = useState<{ id: string; name: string } | null>('vercelProject', () => null);
+const projects = ref<{ id: string; name: string; framework: string | null }[]>([]);
+const loading = ref(false);
+const error = ref('');
+
+const deploymentColor = computed(() => {
+    const state = listStore.currentTodo.vercelDeploymentStatus?.toLowerCase();
+    if (state === 'ready') return 'green';
+    if (state === 'building' || state === 'queued' || state === 'initializing') return 'grey';
+    if (state === 'error' || state === 'canceled') return 'red';
+    return 'grey';
+});
+
+const deploymentVariant = computed(() => {
+    return listStore.currentTodo.vercelDeploymentStatus?.toLowerCase() === 'ready'
+        ? 'tonal'
+        : 'outlined';
+});
+
+async function loadProjects() {
+    loading.value = true;
+    error.value = '';
+    try {
+        const data = await $fetch<{
+            projects: { id: string; name: string; framework: string | null }[];
+        }>('/api/vercel/projects');
+        projects.value = data.projects;
+        if (listStore.currentTodo.vercelProjectId) {
+            selectedProject.value =
+                projects.value.find((p) => p.id === listStore.currentTodo.vercelProjectId) ?? null;
+        }
+    } catch {
+        error.value = 'Failed to load Vercel projects';
+    } finally {
+        loading.value = false;
+    }
+}
+
+onMounted(loadProjects);
+
+onUnmounted(() => {
+    selectedProject.value = null;
+});
+</script>
+
+<template>
+    <v-chip
+        v-if="listStore.currentTodo.vercelProjectId"
+        :color="deploymentColor"
+        :variant="deploymentVariant"
+    >
+        <v-icon icon="mdi-triangle" start />
+        {{ selectedProject?.name ?? listStore.currentTodo.vercelProjectId }}
+        <template #append>
+            <VercelDeploymentOpen />
+            <VercelDeploymentRefresh />
+            <VercelDeploymentUnlink />
+        </template>
+    </v-chip>
+    <v-autocomplete
+        v-else
+        v-model="selectedProject"
+        :items="projects"
+        :loading="loading"
+        item-value="id"
+        item-title="name"
+        return-object
+        label="Vercel Project"
+        placeholder="Select a project"
+        variant="outlined"
+        density="compact"
+        hide-details
+        no-data-text="No projects found"
+        :error-messages="error"
+        prepend-inner-icon="mdi-triangle"
+    >
+        <template #item="{ props, item }">
+            <v-list-item v-bind="props" :subtitle="item.raw.framework ?? ''" />
+        </template>
+        <template #append>
+            <VercelDeploymentLink />
+        </template>
+    </v-autocomplete>
+</template>

--- a/app/components/Vercel/Deployment/Unlink.vue
+++ b/app/components/Vercel/Deployment/Unlink.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+const listStore = useListsStore();
+const selectedProject = useState('vercelProject', () => null);
+
+async function unlinkProject() {
+    selectedProject.value = null;
+    listStore.currentTodo.vercelProjectId = undefined;
+    listStore.currentTodo.vercelDeploymentUrl = undefined;
+    listStore.currentTodo.vercelDeploymentStatus = undefined;
+    await listStore.updateTodo();
+}
+</script>
+
+<template>
+    <v-btn color="red" icon="mdi-link-off" size="small" @click="unlinkProject" />
+</template>

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,9 @@ declare global {
         githubRepo?: string;
         githubLink?: string;
         githubPrLink?: string;
+        vercelProjectId?: string;
+        vercelDeploymentUrl?: string;
+        vercelDeploymentStatus?: string;
         links?: {
             id?: string;
             title: string;

--- a/server/api/vercel/deployment.get.ts
+++ b/server/api/vercel/deployment.get.ts
@@ -1,0 +1,68 @@
+import { defineEventHandler, createError, getQuery } from 'h3';
+import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server';
+import type { Database } from '~~/types/database.types';
+
+export default defineEventHandler(async (event) => {
+    const user = await serverSupabaseUser(event);
+    if (!user) {
+        throw createError({ statusCode: 401, message: 'Unauthorized' });
+    }
+
+    const supabase = await serverSupabaseClient<Database>(event);
+    const { data: userData } = await supabase
+        .from('Users')
+        .select('vercel_access_token, vercel_team_id')
+        .eq('id', user.sub)
+        .single();
+
+    if (!userData?.vercel_access_token) {
+        throw createError({ statusCode: 403, message: 'Vercel integration not connected.' });
+    }
+
+    const { projectId } = getQuery(event);
+    const safeProjectId = Array.isArray(projectId) ? projectId[0] : String(projectId ?? '');
+
+    if (!safeProjectId) {
+        throw createError({ statusCode: 400, message: 'Missing projectId' });
+    }
+
+    const params = new URLSearchParams({
+        projectId: safeProjectId,
+        target: 'production',
+        limit: '1',
+    });
+    if (userData.vercel_team_id) {
+        params.set('teamId', userData.vercel_team_id);
+    }
+
+    let data: any;
+    try {
+        const res = await fetch(`https://api.vercel.com/v6/deployments?${params.toString()}`, {
+            headers: { Authorization: `Bearer ${userData.vercel_access_token}` },
+        });
+        data = await res.json();
+
+        if (!res.ok) {
+            throw new Error(data.error?.message || 'Failed to fetch deployments');
+        }
+    } catch (error: any) {
+        console.error('Error fetching Vercel deployment:', error);
+        throw createError({
+            statusCode: error.status || 500,
+            message: error.message || 'Failed to fetch deployment',
+        });
+    }
+
+    const deployment = data.deployments?.[0];
+    if (!deployment) {
+        throw createError({ statusCode: 404, message: 'No deployments found for this project.' });
+    }
+
+    return {
+        id: deployment.uid,
+        url: `https://${deployment.url}`,
+        state: deployment.state,
+        readyState: deployment.readyState,
+        createdAt: deployment.createdAt || deployment.created,
+    };
+});

--- a/server/api/vercel/projects.get.ts
+++ b/server/api/vercel/projects.get.ts
@@ -1,0 +1,58 @@
+import { defineEventHandler, createError } from 'h3';
+import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server';
+import type { Database } from '~~/types/database.types';
+
+export default defineEventHandler(async (event) => {
+    const user = await serverSupabaseUser(event);
+    if (!user) {
+        throw createError({ statusCode: 401, message: 'Unauthorized' });
+    }
+
+    const supabase = await serverSupabaseClient<Database>(event);
+    const { data: userData } = await supabase
+        .from('Users')
+        .select('vercel_access_token, vercel_team_id')
+        .eq('id', user.sub)
+        .single();
+
+    if (!userData?.vercel_access_token) {
+        throw createError({ statusCode: 403, message: 'Vercel integration not connected.' });
+    }
+
+    const query = userData.vercel_team_id
+        ? `?teamId=${encodeURIComponent(userData.vercel_team_id)}`
+        : '';
+
+    try {
+        const res = await fetch(`https://api.vercel.com/v9/projects${query}`, {
+            headers: { Authorization: `Bearer ${userData.vercel_access_token}` },
+        });
+        const data = await res.json();
+
+        if (!res.ok) {
+            throw new Error(data.error?.message || 'Failed to list projects');
+        }
+
+        return {
+            projects: (data.projects || []).map((project: Record<string, unknown>) => ({
+                id: project.id,
+                name: project.name,
+                framework: project.framework,
+                link: project.link
+                    ? {
+                          type: (project.link as Record<string, unknown>).type,
+                          org: (project.link as Record<string, unknown>).org,
+                          repo: (project.link as Record<string, unknown>).repo,
+                      }
+                    : null,
+                updatedAt: project.updatedAt,
+            })),
+        };
+    } catch (error: any) {
+        console.error('Error listing Vercel projects:', error);
+        throw createError({
+            statusCode: error.status || 500,
+            message: error.message || 'Failed to list projects',
+        });
+    }
+});


### PR DESCRIPTION
## Summary
- Adds `app/components/Vercel/Button.vue` mirroring `Github/Button.vue` — v-menu activator with state-coloured icon (green=ready, red=error, orange=building)
- Adds `Vercel/Deployment/` subcomponents: Select, Link, Open, Unlink, Refresh — mirroring `Github/Branch/*.vue` icon-button-per-action composition
- Select shows autocomplete when unlinked, deployment chip with state colour when linked
- Brings in `/api/vercel/projects` + `/api/vercel/deployment` API routes and `vercelProjectId`/`vercelDeploymentUrl`/`vercelDeploymentStatus` Task type fields from sibling in-review branches

## Test plan
- [ ] Verify Vercel-connected account: button opens menu, project autocomplete loads, Link saves project+deployment to todo
- [ ] Verify deployment chip shows correct colour (green=READY, grey=BUILDING, red=ERROR)
- [ ] Verify Open button opens deployment URL in new tab
- [ ] Verify Refresh updates deployment status
- [ ] Verify Unlink clears all three vercel fields from todo
- [ ] Verify button icon colour reflects deployment state

🤖 Generated with [Claude Code](https://claude.com/claude-code)