### PR TITLE
Show deployment link on Subtask/Recent list views

### DIFF
--- a/app/components/HomePage/Recent.vue
+++ b/app/components/HomePage/Recent.vue
@@ -61,6 +61,7 @@ const rows = computed<RecentRow[]>(() => {
                 todo.name,
                 listName,
                 todo.githubBranchName || '',
+                todo.vercelDeploymentUrl || '',
                 relLabel(todo.createdAt),
                 relLabel(todo.updatedAt),
                 todo.createdAt ? new Date(todo.createdAt).toLocaleDateString('en-GB') : '',
@@ -254,7 +255,20 @@ function toggleStatus(todo: Todo) {
                         <v-icon size="13">mdi-source-branch</v-icon>
                         <span class="branch-name">{{ row.todo.githubBranchName }}</span>
                     </span>
-                    <span v-else class="fglow-text">—</span>
+                    <a
+                        v-if="row.todo.vercelDeploymentUrl"
+                        :href="row.todo.vercelDeploymentUrl"
+                        target="_blank"
+                        class="branch-tag"
+                        @click.stop
+                    >
+                        <v-icon size="13">mdi-rocket-launch-outline</v-icon>
+                    </a>
+                    <span
+                        v-if="!row.todo.githubBranchName && !row.todo.vercelDeploymentUrl"
+                        class="fglow-text"
+                        >—</span
+                    >
                 </div>
 
                 <!-- Last activity cell -->

--- a/app/components/Subtask/index.vue
+++ b/app/components/Subtask/index.vue
@@ -285,6 +285,17 @@ function formatDueDate(date: Date | string | undefined): string {
                     {{ subtask.githubBranchName }}
                 </span>
 
+                <a
+                    v-if="subtask.vercelDeploymentUrl"
+                    :href="subtask.vercelDeploymentUrl"
+                    target="_blank"
+                    class="subtasks__meta subtasks__meta--mono"
+                    :data-testid="`subtask-deploy-${index}`"
+                    @click.stop
+                >
+                    <v-icon size="12">mdi-rocket-launch-outline</v-icon>
+                </a>
+
                 <div
                     class="subtasks__priority-wrap"
                     :class="{ 'subtasks__priority-wrap--set': subtask.priorityLev }"

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,9 @@ declare global {
         githubRepo?: string;
         githubLink?: string;
         githubPrLink?: string;
+        vercelProjectId?: string;
+        vercelDeploymentUrl?: string;
+        vercelDeploymentStatus?: string;
         links?: {
             id?: string;
             title: string;


### PR DESCRIPTION
## Summary
- Adds `mdi-rocket-launch-outline` chip to `Subtask/index.vue` keyed off `subtask.vercelDeploymentUrl` — mirrors the githubBranchName chip, links to deployment URL
- Adds same chip to `HomePage/Recent.vue` branch cell, links to deployment URL
- Adds `todo.vercelDeploymentUrl` to the Recent.vue search haystack so deployment URLs are searchable
- Brings in `vercelProjectId`/`vercelDeploymentUrl`/`vercelDeploymentStatus` Task type fields from sibling in-review branch

## Test plan
- [ ] Linked todo: rocket chip appears in Subtask list and Recent list
- [ ] Clicking rocket chip opens deployment URL in new tab
- [ ] Unlinked todo: no chip, `—` placeholder still shows correctly
- [ ] Recent search by deployment URL finds the todo

🤖 Generated with [Claude Code](https://claude.com/claude-code)