### PR TITLE
Vercel deployment webhook subscription (auto-refresh latest link)

### DIFF
--- a/server/api/vercel/webhook/events.ts
+++ b/server/api/vercel/webhook/events.ts
@@ -1,0 +1,20 @@
+export async function handleDeploymentReady(
+    supabase: any,
+    projectId: string,
+    deploymentUrl: string,
+    state: string,
+    userId: string,
+) {
+    const { error } = await supabase
+        .from('Todos')
+        .update({
+            vercel_deployment_url: deploymentUrl,
+            vercel_deployment_status: state,
+        })
+        .eq('user_id', userId)
+        .eq('vercel_project_id', projectId);
+
+    if (error) {
+        console.error('Error updating todo deployment for Vercel event:', error);
+    }
+}

--- a/server/api/vercel/webhook/index.ts
+++ b/server/api/vercel/webhook/index.ts
@@ -1,0 +1,67 @@
+import { createHmac } from 'node:crypto';
+import { defineEventHandler, getQuery, readRawBody, createError } from 'h3';
+import { serverSupabaseServiceRole } from '#supabase/server';
+import type { Database } from '~~/types/database.types';
+import { handleDeploymentReady } from './events';
+
+type VercelWebhookSubscriptions = {
+    webhookId: string;
+    secret: string;
+    projectIds: string[];
+};
+
+export default defineEventHandler(async (event) => {
+    const supabase = await serverSupabaseServiceRole<Database>(event);
+    const { userId } = getQuery(event);
+
+    if (typeof userId !== 'string') {
+        throw createError({ statusCode: 400, statusMessage: 'Missing userId query parameter' });
+    }
+
+    const { data: userData } = await supabase
+        .from('Users')
+        .select('vercel_webhook_subscriptions')
+        .eq('id', userId)
+        .single();
+
+    const subs = userData?.vercel_webhook_subscriptions as VercelWebhookSubscriptions | null;
+
+    if (!subs?.secret) {
+        throw createError({ statusCode: 403, statusMessage: 'No webhook configuration found' });
+    }
+
+    const rawBody = await readRawBody(event);
+    if (!rawBody) {
+        throw createError({ statusCode: 400, statusMessage: 'Empty request body' });
+    }
+
+    const signature = event.headers.get('x-vercel-signature');
+    const expectedSig = createHmac('sha1', subs.secret).update(rawBody).digest('hex');
+    if (signature !== expectedSig) {
+        throw createError({ statusCode: 401, statusMessage: 'Invalid webhook signature' });
+    }
+
+    let body: any;
+    try {
+        body = JSON.parse(rawBody);
+    } catch {
+        throw createError({ statusCode: 400, statusMessage: 'Invalid JSON body' });
+    }
+
+    const eventType: string = body.type ?? '';
+    const deployment = body.payload?.deployment;
+    const projectId: string = body.payload?.project?.id ?? '';
+
+    if (
+        (eventType === 'deployment.succeeded' || eventType === 'deployment.ready') &&
+        deployment?.url &&
+        projectId
+    ) {
+        const deploymentUrl = `https://${deployment.url}`;
+        const state = deployment.readyState ?? deployment.state ?? 'READY';
+        await handleDeploymentReady(supabase, projectId, deploymentUrl, state, userId);
+        return { status: 'success', message: `${eventType} processed` };
+    }
+
+    return { status: 'ignored', message: `Unhandled Vercel event: ${eventType}` };
+});

--- a/server/api/vercel/webhook/subscribe.delete.ts
+++ b/server/api/vercel/webhook/subscribe.delete.ts
@@ -1,0 +1,111 @@
+import { defineEventHandler, createError, readBody } from 'h3';
+import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server';
+import type { Database } from '~~/types/database.types';
+
+type VercelWebhookSubscriptions = {
+    webhookId: string;
+    secret: string;
+    projectIds: string[];
+};
+
+export default defineEventHandler(async (event) => {
+    const user = await serverSupabaseUser(event);
+    if (!user) {
+        throw createError({ statusCode: 401, message: 'Unauthorized' });
+    }
+
+    const body = await readBody<{ projectIds?: unknown }>(event);
+    const rawProjectIds = body?.projectIds;
+
+    if (!Array.isArray(rawProjectIds)) {
+        throw createError({
+            statusCode: 400,
+            message: 'projectIds must be an array of project ID strings',
+        });
+    }
+
+    const toRemove = new Set(
+        rawProjectIds
+            .filter((item): item is string => typeof item === 'string')
+            .map((s) => s.trim())
+            .filter(Boolean),
+    );
+
+    const supabase = await serverSupabaseClient<Database>(event);
+    const { data: userData, error: userError } = await supabase
+        .from('Users')
+        .select('vercel_access_token, vercel_team_id, vercel_webhook_subscriptions')
+        .eq('id', user.sub)
+        .single();
+
+    if (userError) {
+        throw createError({ statusCode: 500, message: userError.message });
+    }
+
+    if (!userData?.vercel_access_token) {
+        throw createError({ statusCode: 403, message: 'Vercel integration not connected.' });
+    }
+
+    const existing = userData.vercel_webhook_subscriptions as VercelWebhookSubscriptions | null;
+    if (!existing?.webhookId) {
+        return { success: true, projectIds: [] };
+    }
+
+    const token = userData.vercel_access_token;
+    const teamQuery = userData.vercel_team_id ? `?teamId=${userData.vercel_team_id}` : '';
+    const remainingProjectIds = existing.projectIds.filter((id) => !toRemove.has(id));
+
+    try {
+        if (remainingProjectIds.length === 0) {
+            await fetch(`https://api.vercel.com/v1/webhooks/${existing.webhookId}${teamQuery}`, {
+                method: 'DELETE',
+                headers: { Authorization: `Bearer ${token}` },
+            });
+
+            const { error } = await supabase
+                .from('Users')
+                .update({ vercel_webhook_subscriptions: null })
+                .eq('id', user.sub);
+            if (error) throw error;
+
+            return { success: true, projectIds: [] };
+        }
+
+        const patchRes = await fetch(
+            `https://api.vercel.com/v1/webhooks/${existing.webhookId}${teamQuery}`,
+            {
+                method: 'PATCH',
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    events: ['deployment.succeeded', 'deployment.ready'],
+                    projectIds: remainingProjectIds,
+                }),
+            },
+        );
+        if (!patchRes.ok) {
+            const err = await patchRes.json().catch(() => ({}));
+            throw new Error(err?.error?.message || 'Failed to update Vercel webhook');
+        }
+
+        const vercel_webhook_subscriptions = {
+            ...existing,
+            projectIds: remainingProjectIds,
+        } as unknown as Database['public']['Tables']['Users']['Update']['vercel_webhook_subscriptions'];
+
+        const { error } = await supabase
+            .from('Users')
+            .update({ vercel_webhook_subscriptions })
+            .eq('id', user.sub);
+        if (error) throw error;
+
+        return { success: true, projectIds: remainingProjectIds };
+    } catch (error: any) {
+        throw createError({
+            statusCode: error?.status || 500,
+            message: error?.message || 'Failed to unsubscribe Vercel webhook',
+        });
+    }
+});

--- a/server/api/vercel/webhook/subscribe.post.ts
+++ b/server/api/vercel/webhook/subscribe.post.ts
@@ -1,0 +1,136 @@
+import { defineEventHandler, createError, getRequestURL, readBody } from 'h3';
+import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server';
+import type { Database } from '~~/types/database.types';
+
+type VercelWebhookSubscriptions = {
+    webhookId: string;
+    secret: string;
+    projectIds: string[];
+};
+
+export default defineEventHandler(async (event) => {
+    const user = await serverSupabaseUser(event);
+    if (!user) {
+        throw createError({ statusCode: 401, message: 'Unauthorized' });
+    }
+
+    const body = await readBody<{ projectIds?: unknown }>(event);
+    const rawProjectIds = body?.projectIds;
+
+    if (!Array.isArray(rawProjectIds)) {
+        throw createError({
+            statusCode: 400,
+            message: 'projectIds must be an array of project ID strings',
+        });
+    }
+
+    const projectIds = Array.from(
+        new Set(
+            rawProjectIds
+                .filter((item): item is string => typeof item === 'string')
+                .map((s) => s.trim())
+                .filter(Boolean),
+        ),
+    );
+
+    const supabase = await serverSupabaseClient<Database>(event);
+    const { data: userData, error: userError } = await supabase
+        .from('Users')
+        .select('vercel_access_token, vercel_team_id, vercel_webhook_subscriptions')
+        .eq('id', user.sub)
+        .single();
+
+    if (userError) {
+        throw createError({ statusCode: 500, message: userError.message });
+    }
+
+    if (!userData?.vercel_access_token) {
+        throw createError({ statusCode: 403, message: 'Vercel integration not connected.' });
+    }
+
+    const requestUrl = getRequestURL(event);
+    const webhookUrl = `${requestUrl.origin}/api/vercel/webhook?userId=${user.sub}`;
+    const token = userData.vercel_access_token;
+    const teamQuery = userData.vercel_team_id ? `?teamId=${userData.vercel_team_id}` : '';
+
+    const existing = userData.vercel_webhook_subscriptions as VercelWebhookSubscriptions | null;
+
+    let webhookId = existing?.webhookId ?? null;
+    let secret = existing?.secret ?? null;
+
+    try {
+        if (webhookId) {
+            const checkRes = await fetch(
+                `https://api.vercel.com/v1/webhooks/${webhookId}${teamQuery}`,
+                { headers: { Authorization: `Bearer ${token}` } },
+            );
+
+            if (checkRes.status === 404) {
+                webhookId = null;
+                secret = null;
+            } else if (checkRes.ok) {
+                const patchRes = await fetch(
+                    `https://api.vercel.com/v1/webhooks/${webhookId}${teamQuery}`,
+                    {
+                        method: 'PATCH',
+                        headers: {
+                            Authorization: `Bearer ${token}`,
+                            'Content-Type': 'application/json',
+                        },
+                        body: JSON.stringify({
+                            events: ['deployment.succeeded', 'deployment.ready'],
+                            projectIds: projectIds.length ? projectIds : undefined,
+                        }),
+                    },
+                );
+                if (!patchRes.ok) {
+                    const err = await patchRes.json().catch(() => ({}));
+                    throw new Error(err?.error?.message || 'Failed to update Vercel webhook');
+                }
+            }
+        }
+
+        if (!webhookId) {
+            const createRes = await fetch(`https://api.vercel.com/v1/webhooks${teamQuery}`, {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    url: webhookUrl,
+                    events: ['deployment.succeeded', 'deployment.ready'],
+                    ...(projectIds.length ? { projectIds } : {}),
+                }),
+            });
+            const createData = await createRes.json();
+            if (!createRes.ok) {
+                throw new Error(createData?.error?.message || 'Failed to create Vercel webhook');
+            }
+            webhookId = createData.id;
+            secret = createData.secret;
+        }
+
+        const vercel_webhook_subscriptions = {
+            webhookId,
+            secret,
+            projectIds,
+        } as unknown as Database['public']['Tables']['Users']['Update']['vercel_webhook_subscriptions'];
+
+        const { error: updateError } = await supabase
+            .from('Users')
+            .update({ vercel_webhook_subscriptions })
+            .eq('id', user.sub);
+
+        if (updateError) {
+            throw updateError;
+        }
+    } catch (error: any) {
+        throw createError({
+            statusCode: error?.status || 500,
+            message: error?.message || 'Failed to sync Vercel webhook subscriptions',
+        });
+    }
+
+    return { success: true, webhookUrl, projectIds };
+});

--- a/server/api/vercel/webhook/subscriptions.get.ts
+++ b/server/api/vercel/webhook/subscriptions.get.ts
@@ -1,0 +1,31 @@
+import { defineEventHandler, createError } from 'h3';
+import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server';
+import type { Database } from '~~/types/database.types';
+
+export default defineEventHandler(async (event) => {
+    const user = await serverSupabaseUser(event);
+    if (!user) {
+        throw createError({ statusCode: 401, message: 'Unauthorized' });
+    }
+
+    const supabase = await serverSupabaseClient<Database>(event);
+    const { data, error } = await supabase
+        .from('Users')
+        .select('vercel_webhook_subscriptions')
+        .eq('id', user.sub)
+        .single();
+
+    if (error) {
+        throw createError({ statusCode: 500, message: error.message });
+    }
+
+    const subs = data?.vercel_webhook_subscriptions as {
+        webhookId?: string;
+        projectIds?: string[];
+    } | null;
+
+    return {
+        webhookId: subs?.webhookId ?? null,
+        projectIds: subs?.projectIds ?? [],
+    };
+});

--- a/server/mcp/tools/vercel/list-vercel-webhook-subscriptions.ts
+++ b/server/mcp/tools/vercel/list-vercel-webhook-subscriptions.ts
@@ -1,0 +1,10 @@
+import { callApi } from '../../utils/api';
+
+export default defineMcpTool({
+    name: 'list_vercel_webhook_subscriptions',
+    description: 'List Vercel webhook subscriptions for the signed-in user',
+    inputSchema: {},
+    handler: async () => {
+        return await callApi('/api/vercel/webhook/subscriptions');
+    },
+});

--- a/server/mcp/tools/vercel/subscribe-vercel-webhooks.ts
+++ b/server/mcp/tools/vercel/subscribe-vercel-webhooks.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { callApi } from '../../utils/api';
+
+export default defineMcpTool({
+    name: 'subscribe_vercel_webhooks',
+    description:
+        'Register a Vercel deployment webhook for the given project IDs so linked todos auto-update on new production deploys.',
+    inputSchema: {
+        projectIds: z
+            .array(z.string())
+            .describe('Vercel project IDs to subscribe to deployment events'),
+    },
+    handler: async ({ projectIds }) => {
+        return await callApi('/api/vercel/webhook/subscribe', {
+            method: 'POST',
+            body: { projectIds },
+        });
+    },
+});

--- a/server/mcp/tools/vercel/unsubscribe-vercel-webhooks.ts
+++ b/server/mcp/tools/vercel/unsubscribe-vercel-webhooks.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { callApi } from '../../utils/api';
+
+export default defineMcpTool({
+    name: 'unsubscribe_vercel_webhooks',
+    description: 'Remove Vercel deployment webhook subscriptions for the given project IDs.',
+    annotations: { destructiveHint: true },
+    inputSchema: {
+        projectIds: z
+            .array(z.string())
+            .describe('Vercel project IDs to unsubscribe from deployment events'),
+    },
+    handler: async ({ projectIds }) => {
+        return await callApi('/api/vercel/webhook/subscribe', {
+            method: 'DELETE',
+            body: { projectIds },
+        });
+    },
+});


### PR DESCRIPTION
## Summary
- Adds `server/api/vercel/webhook/` — receiver (`index.ts`), event handler (`events.ts`), subscribe (`subscribe.post.ts`), unsubscribe (`subscribe.delete.ts`), list (`subscriptions.get.ts`)
- Webhook receiver verifies `x-vercel-signature` HMAC-SHA1 on every request (fixes the known gap in the GitHub receiver)
- On `deployment.succeeded`/`deployment.ready` events, updates `vercel_deployment_url` + `vercel_deployment_status` on all todos linked to that project
- Subscription model: one webhook per user covering chosen project IDs, stored as `{ webhookId, secret, projectIds }` in `vercel_webhook_subscriptions` JSONB
- Adds 3 MCP tools: `subscribe_vercel_webhooks`, `unsubscribe_vercel_webhooks`, `list_vercel_webhook_subscriptions`

## Test plan
- [ ] Subscribe with project IDs: Vercel webhook created, subscriptions saved to DB
- [ ] Unsubscribe last project: webhook deleted from Vercel, DB cleared
- [ ] Unsubscribe partial: webhook PATCH'd with remaining projects
- [ ] Inbound webhook with valid signature: matched todos updated
- [ ] Inbound webhook with invalid signature: 401 returned
- [ ] Inbound non-deployment event: `ignored` response, no DB writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)