### PR TITLE
Add GitHub Activity Timeline view for lists

### DIFF
--- a/app/components/Github/ActivityTimeline.vue
+++ b/app/components/Github/ActivityTimeline.vue
@@ -137,140 +137,61 @@ watch(() => props.repoName, load);
         <template v-else>
             <div
                 v-if="repoFullName"
-                class="activity-repo d-flex align-center ga-2 mb-4"
+                class="d-flex align-center ga-2 mb-4"
             >
                 <v-icon
                     icon="mdi-github"
                     size="20"
                 />
-                <span class="activity-repo__name">{{ repoFullName }}</span>
+                <span class="text-body-2 text-medium-emphasis">{{ repoFullName }}</span>
             </div>
 
             <div
                 v-for="group in days"
                 :key="group.label"
-                class="activity-day"
+                class="mb-6"
             >
-                <div class="activity-day__label">
+                <div
+                    class="text-caption text-medium-emphasis text-uppercase font-weight-bold mb-2"
+                    style="letter-spacing: 0.04em"
+                >
                     {{ group.label }}
                 </div>
-                <div class="activity-day__rail">
-                    <div class="activity-day__line" />
-                    <div
+                <v-timeline
+                    density="compact"
+                    align="start"
+                    side="end"
+                    truncate-line="both"
+                >
+                    <v-timeline-item
                         v-for="evt in group.events"
                         :key="evt.id"
-                        class="activity-event"
+                        size="small"
+                        :icon="iconFor[evt.type]"
+                        :dot-color="tintFor[evt.type]"
+                        :icon-color="iconColorFor[evt.type]"
                     >
-                        <div
-                            class="activity-event__dot"
-                            :style="{ background: tintFor[evt.type] }"
-                        >
-                            <v-icon
-                                :icon="iconFor[evt.type]"
-                                size="12"
-                                :color="iconColorFor[evt.type]"
-                            />
+                        <div class="d-flex align-center ga-2">
+                            <a
+                                :href="evt.url"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="text-body-2 font-weight-bold text-truncate text-decoration-none text-high-emphasis flex-grow-1"
+                            >
+                                {{ evt.summary }}
+                            </a>
+                            <span class="text-caption text-medium-emphasis text-no-wrap">
+                                {{
+                                    new Date(evt.createdAt).toLocaleTimeString('en-US', {
+                                        hour: 'numeric',
+                                        minute: '2-digit',
+                                    })
+                                }}
+                            </span>
                         </div>
-                        <a
-                            :href="evt.url"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            class="activity-event__summary text-truncate"
-                        >
-                            {{ evt.summary }}
-                        </a>
-                        <div class="activity-event__time">
-                            {{
-                                new Date(evt.createdAt).toLocaleTimeString('en-US', {
-                                    hour: 'numeric',
-                                    minute: '2-digit',
-                                })
-                            }}
-                        </div>
-                    </div>
-                </div>
+                    </v-timeline-item>
+                </v-timeline>
             </div>
         </template>
     </div>
 </template>
-
-<style scoped>
-.activity-repo__name {
-    font-size: 0.8125rem;
-    color: rgba(42, 52, 57, 0.6);
-}
-
-.activity-day {
-    margin-bottom: 24px;
-}
-
-.activity-day__label {
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: rgba(42, 52, 57, 0.6);
-    margin-bottom: 10px;
-}
-
-.activity-day__rail {
-    position: relative;
-    padding-left: 30px;
-}
-
-.activity-day__line {
-    position: absolute;
-    left: 9px;
-    top: 4px;
-    bottom: 4px;
-    width: 2px;
-    background: rgba(113, 124, 130, 0.16);
-}
-
-.activity-event {
-    position: relative;
-    padding: 9px 0 9px 14px;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-}
-
-.activity-event__dot {
-    position: absolute;
-    left: -30px;
-    top: 50%;
-    transform: translateY(-50%);
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 1;
-    flex-shrink: 0;
-}
-
-.activity-event__summary {
-    flex: 1;
-    min-width: 0;
-    font-family: Manrope, sans-serif;
-    font-weight: 700;
-    font-size: 0.9375rem;
-    color: #2a3439;
-    text-decoration: none;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-}
-
-.activity-event__summary:hover {
-    color: #005ac2;
-}
-
-.activity-event__time {
-    font-size: 0.8125rem;
-    color: rgba(42, 52, 57, 0.6);
-    white-space: nowrap;
-    flex-shrink: 0;
-}
-</style>

--- a/app/components/Github/ActivityTimeline.vue
+++ b/app/components/Github/ActivityTimeline.vue
@@ -58,7 +58,7 @@ const days = computed<DayGroup[]>(() => {
     const groups: DayGroup[] = [];
     for (const evt of events.value) {
         const label = dayLabel(evt.createdAt);
-        let group = groups.find(g => g.label === label);
+        let group = groups.find((g) => g.label === label);
         if (!group) {
             group = { label, events: [] };
             groups.push(group);
@@ -71,10 +71,9 @@ const days = computed<DayGroup[]>(() => {
 async function resolveOwner(): Promise<string | null> {
     try {
         const data = await $fetch<{ repositories: Repo[] }>('/api/github/repos');
-        const repo = data.repositories.find(r => r.name === props.repoName);
+        const repo = data.repositories.find((r) => r.name === props.repoName);
         return repo?.full_name?.split('/').shift() ?? null;
-    }
-    catch {
+    } catch {
         return null;
     }
 }
@@ -94,8 +93,7 @@ async function load() {
             query: { owner, repo: props.repoName },
         });
         events.value = data.events;
-    }
-    catch (e: any) {
+    } catch (e: any) {
         error.value = e?.data?.message || 'Failed to load GitHub activity';
     }
     loading.value = false;
@@ -107,23 +105,11 @@ watch(() => props.repoName, load);
 
 <template>
     <div class="activity-timeline">
-        <div
-            v-if="loading"
-            class="d-flex align-center justify-center py-8"
-        >
-            <v-progress-circular
-                indeterminate
-                size="28"
-                color="primary"
-            />
+        <div v-if="loading" class="d-flex align-center justify-center py-8">
+            <v-progress-circular indeterminate size="28" color="primary" />
         </div>
 
-        <v-alert
-            v-else-if="error"
-            type="error"
-            variant="tonal"
-            class="ma-4"
-        >
+        <v-alert v-else-if="error" type="error" variant="tonal" class="ma-4">
             {{ error }}
         </v-alert>
 
@@ -135,34 +121,19 @@ watch(() => props.repoName, load);
         />
 
         <template v-else>
-            <div
-                v-if="repoFullName"
-                class="d-flex align-center ga-2 mb-4"
-            >
-                <v-icon
-                    icon="mdi-github"
-                    size="20"
-                />
+            <div v-if="repoFullName" class="d-flex align-center ga-2 mb-4">
+                <v-icon icon="mdi-github" size="20" />
                 <span class="text-body-2 text-medium-emphasis">{{ repoFullName }}</span>
             </div>
 
-            <div
-                v-for="group in days"
-                :key="group.label"
-                class="mb-6"
-            >
+            <div v-for="group in days" :key="group.label" class="mb-6">
                 <div
                     class="text-caption text-medium-emphasis text-uppercase font-weight-bold mb-2"
                     style="letter-spacing: 0.04em"
                 >
                     {{ group.label }}
                 </div>
-                <v-timeline
-                    density="compact"
-                    align="start"
-                    side="end"
-                    truncate-line="both"
-                >
+                <v-timeline density="compact" align="start" side="end" truncate-line="both">
                     <v-timeline-item
                         v-for="evt in group.events"
                         :key="evt.id"

--- a/app/components/Github/ActivityTimeline.vue
+++ b/app/components/Github/ActivityTimeline.vue
@@ -1,0 +1,276 @@
+<script setup lang="ts">
+import type { Repo } from '~/components/Github/RepoSelect.vue';
+
+type EventType = 'commit' | 'pr' | 'branch';
+
+interface ActivityEvent {
+    id: string;
+    type: EventType;
+    summary: string;
+    url: string;
+    createdAt: string;
+}
+
+interface DayGroup {
+    label: string;
+    events: ActivityEvent[];
+}
+
+const props = defineProps<{
+    repoName: string;
+}>();
+
+const loading = ref(false);
+const error = ref('');
+const events = ref<ActivityEvent[]>([]);
+const repoFullName = ref('');
+
+const iconFor: Record<EventType, string> = {
+    commit: 'mdi-source-commit',
+    pr: 'mdi-source-pull',
+    branch: 'mdi-source-branch',
+};
+
+const tintFor: Record<EventType, string> = {
+    commit: '#d8e2ff',
+    pr: '#d3f5df',
+    branch: '#e1e9ee',
+};
+
+const iconColorFor: Record<EventType, string> = {
+    commit: '#004eaa',
+    pr: '#1b8a3d',
+    branch: 'rgba(42, 52, 57, 0.6)',
+};
+
+function dayLabel(dateStr: string): string {
+    const d = new Date(dateStr);
+    const now = new Date();
+    const startOfDay = (date: Date) =>
+        new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    const diffDays = Math.round((startOfDay(now).getTime() - startOfDay(d).getTime()) / 86400000);
+    if (diffDays === 0) return 'Today';
+    if (diffDays === 1) return 'Yesterday';
+    return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+const days = computed<DayGroup[]>(() => {
+    const groups: DayGroup[] = [];
+    for (const evt of events.value) {
+        const label = dayLabel(evt.createdAt);
+        let group = groups.find(g => g.label === label);
+        if (!group) {
+            group = { label, events: [] };
+            groups.push(group);
+        }
+        group.events.push(evt);
+    }
+    return groups;
+});
+
+async function resolveOwner(): Promise<string | null> {
+    try {
+        const data = await $fetch<{ repositories: Repo[] }>('/api/github/repos');
+        const repo = data.repositories.find(r => r.name === props.repoName);
+        return repo?.full_name?.split('/').shift() ?? null;
+    }
+    catch {
+        return null;
+    }
+}
+
+async function load() {
+    if (!props.repoName) return;
+    loading.value = true;
+    error.value = '';
+    try {
+        const owner = await resolveOwner();
+        if (!owner) {
+            error.value = 'Could not find repository owner';
+            return;
+        }
+        repoFullName.value = `${owner}/${props.repoName}`;
+        const data = await $fetch<{ events: ActivityEvent[] }>('/api/github/activity', {
+            query: { owner, repo: props.repoName },
+        });
+        events.value = data.events;
+    }
+    catch (e: any) {
+        error.value = e?.data?.message || 'Failed to load GitHub activity';
+    }
+    loading.value = false;
+}
+
+onMounted(load);
+watch(() => props.repoName, load);
+</script>
+
+<template>
+    <div class="activity-timeline">
+        <div
+            v-if="loading"
+            class="d-flex align-center justify-center py-8"
+        >
+            <v-progress-circular
+                indeterminate
+                size="28"
+                color="primary"
+            />
+        </div>
+
+        <v-alert
+            v-else-if="error"
+            type="error"
+            variant="tonal"
+            class="ma-4"
+        >
+            {{ error }}
+        </v-alert>
+
+        <v-empty-state
+            v-else-if="!events.length"
+            icon="mdi-github"
+            title="No activity yet"
+            text="Commits, pull requests, and new branches for this repository will show up here."
+        />
+
+        <template v-else>
+            <div
+                v-if="repoFullName"
+                class="activity-repo d-flex align-center ga-2 mb-4"
+            >
+                <v-icon
+                    icon="mdi-github"
+                    size="20"
+                />
+                <span class="activity-repo__name">{{ repoFullName }}</span>
+            </div>
+
+            <div
+                v-for="group in days"
+                :key="group.label"
+                class="activity-day"
+            >
+                <div class="activity-day__label">
+                    {{ group.label }}
+                </div>
+                <div class="activity-day__rail">
+                    <div class="activity-day__line" />
+                    <div
+                        v-for="evt in group.events"
+                        :key="evt.id"
+                        class="activity-event"
+                    >
+                        <div
+                            class="activity-event__dot"
+                            :style="{ background: tintFor[evt.type] }"
+                        >
+                            <v-icon
+                                :icon="iconFor[evt.type]"
+                                size="12"
+                                :color="iconColorFor[evt.type]"
+                            />
+                        </div>
+                        <a
+                            :href="evt.url"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="activity-event__summary text-truncate"
+                        >
+                            {{ evt.summary }}
+                        </a>
+                        <div class="activity-event__time">
+                            {{
+                                new Date(evt.createdAt).toLocaleTimeString('en-US', {
+                                    hour: 'numeric',
+                                    minute: '2-digit',
+                                })
+                            }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </template>
+    </div>
+</template>
+
+<style scoped>
+.activity-repo__name {
+    font-size: 0.8125rem;
+    color: rgba(42, 52, 57, 0.6);
+}
+
+.activity-day {
+    margin-bottom: 24px;
+}
+
+.activity-day__label {
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: rgba(42, 52, 57, 0.6);
+    margin-bottom: 10px;
+}
+
+.activity-day__rail {
+    position: relative;
+    padding-left: 30px;
+}
+
+.activity-day__line {
+    position: absolute;
+    left: 9px;
+    top: 4px;
+    bottom: 4px;
+    width: 2px;
+    background: rgba(113, 124, 130, 0.16);
+}
+
+.activity-event {
+    position: relative;
+    padding: 9px 0 9px 14px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.activity-event__dot {
+    position: absolute;
+    left: -30px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1;
+    flex-shrink: 0;
+}
+
+.activity-event__summary {
+    flex: 1;
+    min-width: 0;
+    font-family: Manrope, sans-serif;
+    font-weight: 700;
+    font-size: 0.9375rem;
+    color: #2a3439;
+    text-decoration: none;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+
+.activity-event__summary:hover {
+    color: #005ac2;
+}
+
+.activity-event__time {
+    font-size: 0.8125rem;
+    color: rgba(42, 52, 57, 0.6);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+</style>

--- a/app/pages/list/[id]/index.vue
+++ b/app/pages/list/[id]/index.vue
@@ -48,26 +48,16 @@ const views = computed(() => {
 
 <template>
     <div class="overflow-y-auto fill-height flex-grow-1">
-        <div
-            class="mx-auto px-7 pt-7 pb-12"
-            style="width: 100%"
-        >
+        <div class="mx-auto px-7 pt-7 pb-12" style="width: 100%">
             <div>
                 <!-- Header -->
-                <v-row
-                    no-gutters
-                    align="center"
-                    class="mb-4 flex-nowrap ga-3"
-                >
+                <v-row no-gutters align="center" class="mb-4 flex-nowrap ga-3">
                     <v-col class="overflow-hidden">
                         <h1 class="list-title text-truncate ma-0">
                             {{ listsStore.currentList?.name }}
                         </h1>
                     </v-col>
-                    <v-col
-                        cols="auto"
-                        class="d-flex align-center ga-3 flex-shrink-0"
-                    >
+                    <v-col cols="auto" class="d-flex align-center ga-3 flex-shrink-0">
                         <span
                             class="text-medium-emphasis text-body-2 font-weight-medium text-no-wrap"
                         >
@@ -95,18 +85,13 @@ const views = computed(() => {
                     class="add-task-bar d-flex align-center px-4 mb-5 ga-3"
                     data-testid="new-todo-input"
                 >
-                    <v-icon
-                        color="primary"
-                        size="18"
-                    >
-                        mdi-plus
-                    </v-icon>
+                    <v-icon color="primary" size="18"> mdi-plus </v-icon>
                     <input
                         v-model="newTodoName"
                         placeholder="Add a task…"
                         class="add-task-input flex-grow-1"
                         @keydown.enter="addTodo"
-                    >
+                    />
                 </div>
             </div>
 

--- a/app/pages/list/[id]/index.vue
+++ b/app/pages/list/[id]/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const listsStore = useListsStore();
 
-type View = 'list' | 'table' | 'board';
+type View = 'list' | 'table' | 'board' | 'activity';
 
 const currentView = ref<View>('list');
 const newTodoName = ref('');
@@ -34,25 +34,40 @@ async function addTodo() {
     newTodoName.value = '';
 }
 
-const views: { key: View; icon: string; label: string }[] = [
+const baseViews: { key: View; icon: string; label: string }[] = [
     { key: 'list', icon: 'mdi-format-list-bulleted', label: 'List' },
     { key: 'table', icon: 'mdi-table', label: 'Table' },
     { key: 'board', icon: 'mdi-view-column-outline', label: 'Board' },
 ];
+
+const views = computed(() => {
+    if (!listsStore.currentList?.githubRepo) return baseViews;
+    return [...baseViews, { key: 'activity' as View, icon: 'mdi-github', label: 'Activity' }];
+});
 </script>
 
 <template>
     <div class="overflow-y-auto fill-height flex-grow-1">
-        <div class="mx-auto px-7 pt-7 pb-12" style="width: 100%">
+        <div
+            class="mx-auto px-7 pt-7 pb-12"
+            style="width: 100%"
+        >
             <div>
                 <!-- Header -->
-                <v-row no-gutters align="center" class="mb-4 flex-nowrap ga-3">
+                <v-row
+                    no-gutters
+                    align="center"
+                    class="mb-4 flex-nowrap ga-3"
+                >
                     <v-col class="overflow-hidden">
                         <h1 class="list-title text-truncate ma-0">
                             {{ listsStore.currentList?.name }}
                         </h1>
                     </v-col>
-                    <v-col cols="auto" class="d-flex align-center ga-3 flex-shrink-0">
+                    <v-col
+                        cols="auto"
+                        class="d-flex align-center ga-3 flex-shrink-0"
+                    >
                         <span
                             class="text-medium-emphasis text-body-2 font-weight-medium text-no-wrap"
                         >
@@ -80,13 +95,18 @@ const views: { key: View; icon: string; label: string }[] = [
                     class="add-task-bar d-flex align-center px-4 mb-5 ga-3"
                     data-testid="new-todo-input"
                 >
-                    <v-icon color="primary" size="18"> mdi-plus </v-icon>
+                    <v-icon
+                        color="primary"
+                        size="18"
+                    >
+                        mdi-plus
+                    </v-icon>
                     <input
                         v-model="newTodoName"
                         placeholder="Add a task…"
                         class="add-task-input flex-grow-1"
                         @keydown.enter="addTodo"
-                    />
+                    >
                 </div>
             </div>
 
@@ -109,6 +129,10 @@ const views: { key: View; icon: string; label: string }[] = [
                 <ListTable />
             </div>
             <Board v-else-if="currentView === 'board'" />
+            <GithubActivityTimeline
+                v-else-if="currentView === 'activity'"
+                :repo-name="listsStore.currentList.githubRepo"
+            />
         </div>
     </div>
 </template>

--- a/server/api/github/activity.get.ts
+++ b/server/api/github/activity.get.ts
@@ -2,78 +2,11 @@ import { defineEventHandler, createError, getQuery } from 'h3';
 import { App } from 'octokit';
 import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server';
 import type { Database } from '~~/types/database.types';
-
-export type GithubActivityEventType = 'commit' | 'pr' | 'branch';
-
-export interface GithubActivityEvent {
-    id: string;
-    type: GithubActivityEventType;
-    summary: string;
-    url: string;
-    createdAt: string;
-}
-
-interface RawRepoEvent {
-    id: string;
-    type: string | null;
-    created_at: string | null;
-    payload: {
-        ref?: string;
-        ref_type?: string;
-        action?: string;
-        commits?: { sha: string; message: string }[];
-        pull_request?: { title: string; html_url: string; merged: boolean };
-    };
-}
-
-function normalizeEvent(event: RawRepoEvent, repoFullName: string): GithubActivityEvent[] {
-    const createdAt = event.created_at;
-    if (!createdAt) return [];
-
-    if (event.type === 'PushEvent') {
-        const commits = event.payload?.commits ?? [];
-        return commits.map((commit, index) => ({
-            id: `${event.id}-${index}`,
-            type: 'commit' as const,
-            summary: (commit.message || '').split('\n')[0],
-            url: `https://github.com/${repoFullName}/commit/${commit.sha}`,
-            createdAt,
-        }));
-    }
-
-    if (event.type === 'PullRequestEvent') {
-        const pr = event.payload?.pull_request;
-        if (!pr) return [];
-        const merged = event.payload?.action === 'closed' && pr.merged;
-        const opened = event.payload?.action === 'opened';
-        if (!merged && !opened) return [];
-        return [
-            {
-                id: event.id,
-                type: 'pr' as const,
-                summary: `${merged ? 'Merged PR' : 'Opened PR'}: ${pr.title}`,
-                url: pr.html_url,
-                createdAt,
-            },
-        ];
-    }
-
-    if (event.type === 'CreateEvent' && event.payload?.ref_type === 'branch') {
-        const ref = event.payload.ref;
-        if (!ref) return [];
-        return [
-            {
-                id: event.id,
-                type: 'branch' as const,
-                summary: `Created branch ${ref}`,
-                url: `https://github.com/${repoFullName}/tree/${ref}`,
-                createdAt,
-            },
-        ];
-    }
-
-    return [];
-}
+import {
+    buildActivityFeed,
+    type GithubActivityEvent,
+    type RawRepoEvent,
+} from '../../utils/githubActivity';
 
 export default defineEventHandler(async (event): Promise<{ events: GithubActivityEvent[] }> => {
     const user = await serverSupabaseUser(event);
@@ -118,10 +51,7 @@ export default defineEventHandler(async (event): Promise<{ events: GithubActivit
         });
 
         const repoFullName = `${owner}/${repo}`;
-        const events = (data as unknown as RawRepoEvent[])
-            .flatMap(raw => normalizeEvent(raw, repoFullName))
-            .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-            .slice(0, 40);
+        const events = buildActivityFeed(data as unknown as RawRepoEvent[], repoFullName);
 
         return { events };
     }

--- a/server/api/github/activity.get.ts
+++ b/server/api/github/activity.get.ts
@@ -1,0 +1,135 @@
+import { defineEventHandler, createError, getQuery } from 'h3';
+import { App } from 'octokit';
+import { serverSupabaseClient, serverSupabaseUser } from '#supabase/server';
+import type { Database } from '~~/types/database.types';
+
+export type GithubActivityEventType = 'commit' | 'pr' | 'branch';
+
+export interface GithubActivityEvent {
+    id: string;
+    type: GithubActivityEventType;
+    summary: string;
+    url: string;
+    createdAt: string;
+}
+
+interface RawRepoEvent {
+    id: string;
+    type: string | null;
+    created_at: string | null;
+    payload: {
+        ref?: string;
+        ref_type?: string;
+        action?: string;
+        commits?: { sha: string; message: string }[];
+        pull_request?: { title: string; html_url: string; merged: boolean };
+    };
+}
+
+function normalizeEvent(event: RawRepoEvent, repoFullName: string): GithubActivityEvent[] {
+    const createdAt = event.created_at;
+    if (!createdAt) return [];
+
+    if (event.type === 'PushEvent') {
+        const commits = event.payload?.commits ?? [];
+        return commits.map((commit, index) => ({
+            id: `${event.id}-${index}`,
+            type: 'commit' as const,
+            summary: (commit.message || '').split('\n')[0],
+            url: `https://github.com/${repoFullName}/commit/${commit.sha}`,
+            createdAt,
+        }));
+    }
+
+    if (event.type === 'PullRequestEvent') {
+        const pr = event.payload?.pull_request;
+        if (!pr) return [];
+        const merged = event.payload?.action === 'closed' && pr.merged;
+        const opened = event.payload?.action === 'opened';
+        if (!merged && !opened) return [];
+        return [
+            {
+                id: event.id,
+                type: 'pr' as const,
+                summary: `${merged ? 'Merged PR' : 'Opened PR'}: ${pr.title}`,
+                url: pr.html_url,
+                createdAt,
+            },
+        ];
+    }
+
+    if (event.type === 'CreateEvent' && event.payload?.ref_type === 'branch') {
+        const ref = event.payload.ref;
+        if (!ref) return [];
+        return [
+            {
+                id: event.id,
+                type: 'branch' as const,
+                summary: `Created branch ${ref}`,
+                url: `https://github.com/${repoFullName}/tree/${ref}`,
+                createdAt,
+            },
+        ];
+    }
+
+    return [];
+}
+
+export default defineEventHandler(async (event): Promise<{ events: GithubActivityEvent[] }> => {
+    const user = await serverSupabaseUser(event);
+    if (!user) {
+        throw createError({ statusCode: 401, message: 'Unauthorized' });
+    }
+
+    const supabase = await serverSupabaseClient<Database>(event);
+    const { data: userData } = await supabase
+        .from('Users')
+        .select('github_installation_id')
+        .eq('id', user.sub)
+        .single();
+
+    if (!userData?.github_installation_id) {
+        throw createError({ statusCode: 403, message: 'GitHub integration not connected.' });
+    }
+
+    const query = getQuery(event);
+    const owner = String(query.owner ?? '');
+    const repo = String(query.repo ?? '');
+
+    if (!owner || !repo) {
+        throw createError({
+            statusCode: 400,
+            message: 'Missing owner or repo in query parameters',
+        });
+    }
+
+    const config = useRuntimeConfig();
+    const app = new App({
+        appId: config.private.github.appId,
+        privateKey: config.private.github.privateKey,
+    });
+    const octokit = await app.getInstallationOctokit(userData.github_installation_id);
+
+    try {
+        const { data } = await octokit.rest.activity.listRepoEvents({
+            owner,
+            repo,
+            per_page: 30,
+        });
+
+        const repoFullName = `${owner}/${repo}`;
+        const events = (data as unknown as RawRepoEvent[])
+            .flatMap(raw => normalizeEvent(raw, repoFullName))
+            .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+            .slice(0, 40);
+
+        return { events };
+    }
+    catch (error: any) {
+        console.error('Error loading GitHub activity:', error);
+        throw createError({
+            statusCode: error.status || 500,
+            message: error.message || 'Failed to load GitHub activity',
+        });
+    }
+});

--- a/server/api/github/activity.get.ts
+++ b/server/api/github/activity.get.ts
@@ -54,8 +54,7 @@ export default defineEventHandler(async (event): Promise<{ events: GithubActivit
         const events = buildActivityFeed(data as unknown as RawRepoEvent[], repoFullName);
 
         return { events };
-    }
-    catch (error: any) {
+    } catch (error: any) {
         console.error('Error loading GitHub activity:', error);
         throw createError({
             statusCode: error.status || 500,

--- a/server/utils/githubActivity.ts
+++ b/server/utils/githubActivity.ts
@@ -17,7 +17,7 @@ export interface RawRepoEvent {
         ref_type?: string;
         action?: string;
         commits?: { sha: string; message: string }[];
-        pull_request?: { title: string; html_url: string; merged: boolean };
+        pull_request?: { number: number; title: string; merged: boolean };
     };
 }
 
@@ -46,8 +46,8 @@ export function normalizeEvent(event: RawRepoEvent, repoFullName: string): Githu
             {
                 id: event.id,
                 type: 'pr' as const,
-                summary: `${merged ? 'Merged PR' : 'Opened PR'}: ${pr.title}`,
-                url: pr.html_url,
+                summary: `${merged ? 'Merged PR' : 'Opened PR'}: #${pr.number}`,
+                url: `https://github.com/${repoFullName}/pull/${pr.number}`,
                 createdAt,
             },
         ];
@@ -75,7 +75,7 @@ export function buildActivityFeed(
     repoFullName: string,
 ): GithubActivityEvent[] {
     return rawEvents
-        .flatMap(raw => normalizeEvent(raw, repoFullName))
+        .flatMap((raw) => normalizeEvent(raw, repoFullName))
         .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
         .slice(0, 40);
 }

--- a/server/utils/githubActivity.ts
+++ b/server/utils/githubActivity.ts
@@ -1,0 +1,81 @@
+export type GithubActivityEventType = 'commit' | 'pr' | 'branch';
+
+export interface GithubActivityEvent {
+    id: string;
+    type: GithubActivityEventType;
+    summary: string;
+    url: string;
+    createdAt: string;
+}
+
+export interface RawRepoEvent {
+    id: string;
+    type: string | null;
+    created_at: string | null;
+    payload: {
+        ref?: string;
+        ref_type?: string;
+        action?: string;
+        commits?: { sha: string; message: string }[];
+        pull_request?: { title: string; html_url: string; merged: boolean };
+    };
+}
+
+export function normalizeEvent(event: RawRepoEvent, repoFullName: string): GithubActivityEvent[] {
+    const createdAt = event.created_at;
+    if (!createdAt) return [];
+
+    if (event.type === 'PushEvent') {
+        const commits = event.payload?.commits ?? [];
+        return commits.map((commit, index) => ({
+            id: `${event.id}-${index}`,
+            type: 'commit' as const,
+            summary: (commit.message || '').split('\n')[0],
+            url: `https://github.com/${repoFullName}/commit/${commit.sha}`,
+            createdAt,
+        }));
+    }
+
+    if (event.type === 'PullRequestEvent') {
+        const pr = event.payload?.pull_request;
+        if (!pr) return [];
+        const merged = event.payload?.action === 'closed' && pr.merged;
+        const opened = event.payload?.action === 'opened';
+        if (!merged && !opened) return [];
+        return [
+            {
+                id: event.id,
+                type: 'pr' as const,
+                summary: `${merged ? 'Merged PR' : 'Opened PR'}: ${pr.title}`,
+                url: pr.html_url,
+                createdAt,
+            },
+        ];
+    }
+
+    if (event.type === 'CreateEvent' && event.payload?.ref_type === 'branch') {
+        const ref = event.payload.ref;
+        if (!ref) return [];
+        return [
+            {
+                id: event.id,
+                type: 'branch' as const,
+                summary: `Created branch ${ref}`,
+                url: `https://github.com/${repoFullName}/tree/${ref}`,
+                createdAt,
+            },
+        ];
+    }
+
+    return [];
+}
+
+export function buildActivityFeed(
+    rawEvents: RawRepoEvent[],
+    repoFullName: string,
+): GithubActivityEvent[] {
+    return rawEvents
+        .flatMap(raw => normalizeEvent(raw, repoFullName))
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+        .slice(0, 40);
+}

--- a/test/unit/api/github-activity.test.ts
+++ b/test/unit/api/github-activity.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildActivityFeed,
+    normalizeEvent,
+    type RawRepoEvent,
+} from '../../../server/utils/githubActivity';
+
+const REPO = 'proggreg/tickup';
+
+function pushEvent(overrides: Partial<RawRepoEvent> = {}): RawRepoEvent {
+    return {
+        id: 'push-1',
+        type: 'PushEvent',
+        created_at: '2026-08-02T11:02:00Z',
+        payload: {
+            commits: [{ sha: 'a1b2c3d', message: 'Add sort-by-priority to todo list' }],
+        },
+        ...overrides,
+    };
+}
+
+function pullRequestEvent(overrides: Partial<RawRepoEvent> = {}): RawRepoEvent {
+    return {
+        id: 'pr-1',
+        type: 'PullRequestEvent',
+        created_at: '2026-08-02T14:14:00Z',
+        payload: {
+            action: 'opened',
+            pull_request: {
+                title: 'Fix overdue badge on list cards',
+                html_url: `https://github.com/${REPO}/pull/42`,
+                merged: false,
+            },
+        },
+        ...overrides,
+    };
+}
+
+function createBranchEvent(overrides: Partial<RawRepoEvent> = {}): RawRepoEvent {
+    return {
+        id: 'create-1',
+        type: 'CreateEvent',
+        created_at: '2026-08-01T16:30:00Z',
+        payload: { ref: 'feature/kanban-drag', ref_type: 'branch' },
+        ...overrides,
+    };
+}
+
+describe('normalizeEvent', () => {
+    it('maps a PushEvent to one commit entry per commit', () => {
+        const event = pushEvent({
+            payload: {
+                commits: [
+                    { sha: 'sha1', message: 'First commit\n\nlonger body' },
+                    { sha: 'sha2', message: 'Second commit' },
+                ],
+            },
+        });
+
+        const result = normalizeEvent(event, REPO);
+
+        expect(result).toHaveLength(2);
+        expect(result[0]).toMatchObject({
+            id: 'push-1-0',
+            type: 'commit',
+            summary: 'First commit',
+            url: `https://github.com/${REPO}/commit/sha1`,
+        });
+        expect(result[1]).toMatchObject({
+            id: 'push-1-1',
+            type: 'commit',
+            summary: 'Second commit',
+            url: `https://github.com/${REPO}/commit/sha2`,
+        });
+    });
+
+    it('maps an opened PullRequestEvent to a pr entry', () => {
+        const [result] = normalizeEvent(pullRequestEvent(), REPO);
+
+        expect(result).toMatchObject({
+            type: 'pr',
+            summary: 'Opened PR: Fix overdue badge on list cards',
+            url: `https://github.com/${REPO}/pull/42`,
+        });
+    });
+
+    it('maps a merged PullRequestEvent to a "Merged PR" entry', () => {
+        const event = pullRequestEvent({
+            payload: {
+                action: 'closed',
+                pull_request: {
+                    title: 'Search full-text index',
+                    html_url: `https://github.com/${REPO}/pull/41`,
+                    merged: true,
+                },
+            },
+        });
+
+        const [result] = normalizeEvent(event, REPO);
+
+        expect(result.summary).toBe('Merged PR: Search full-text index');
+    });
+
+    it('drops a closed-but-not-merged PullRequestEvent', () => {
+        const event = pullRequestEvent({
+            payload: {
+                action: 'closed',
+                pull_request: {
+                    title: 'Abandoned change',
+                    html_url: `https://github.com/${REPO}/pull/99`,
+                    merged: false,
+                },
+            },
+        });
+
+        expect(normalizeEvent(event, REPO)).toEqual([]);
+    });
+
+    it('maps a branch CreateEvent to a branch entry', () => {
+        const [result] = normalizeEvent(createBranchEvent(), REPO);
+
+        expect(result).toMatchObject({
+            type: 'branch',
+            summary: 'Created branch feature/kanban-drag',
+            url: `https://github.com/${REPO}/tree/feature/kanban-drag`,
+        });
+    });
+
+    it('drops a tag CreateEvent', () => {
+        const event = createBranchEvent({ payload: { ref: 'v1.0.0', ref_type: 'tag' } });
+
+        expect(normalizeEvent(event, REPO)).toEqual([]);
+    });
+
+    it('drops event types it does not understand', () => {
+        const event: RawRepoEvent = {
+            id: 'watch-1',
+            type: 'WatchEvent',
+            created_at: '2026-08-02T10:00:00Z',
+            payload: {},
+        };
+
+        expect(normalizeEvent(event, REPO)).toEqual([]);
+    });
+
+    it('drops events with no created_at', () => {
+        const event = pushEvent({ created_at: null });
+
+        expect(normalizeEvent(event, REPO)).toEqual([]);
+    });
+});
+
+describe('buildActivityFeed', () => {
+    it('sorts merged events newest-first regardless of input order', () => {
+        const oldest = createBranchEvent(); // 2026-08-01T16:30:00Z
+        const middle = pushEvent(); // 2026-08-02T11:02:00Z
+        const newest = pullRequestEvent(); // 2026-08-02T14:14:00Z
+
+        const feed = buildActivityFeed([oldest, newest, middle], REPO);
+
+        expect(feed.map(e => e.id)).toEqual([newest.id, `${middle.id}-0`, oldest.id]);
+    });
+
+    it('caps the feed at 40 events', () => {
+        const events: RawRepoEvent[] = Array.from({ length: 50 }, (_, i) =>
+            createBranchEvent({
+                id: `create-${i}`,
+                payload: { ref: `branch-${i}`, ref_type: 'branch' },
+                created_at: new Date(2026, 0, 1, 0, i).toISOString(),
+            }),
+        );
+
+        const feed = buildActivityFeed(events, REPO);
+
+        expect(feed).toHaveLength(40);
+    });
+
+    it('flattens and filters across mixed event types', () => {
+        const feed = buildActivityFeed(
+            [
+                createBranchEvent(),
+                pushEvent(),
+                pullRequestEvent(),
+                { ...pushEvent(), type: 'WatchEvent' },
+            ],
+            REPO,
+        );
+
+        expect(feed.map(e => e.type)).toEqual(['pr', 'commit', 'branch']);
+    });
+});

--- a/test/unit/api/github-activity.test.ts
+++ b/test/unit/api/github-activity.test.ts
@@ -158,7 +158,7 @@ describe('buildActivityFeed', () => {
 
         const feed = buildActivityFeed([oldest, newest, middle], REPO);
 
-        expect(feed.map(e => e.id)).toEqual([newest.id, `${middle.id}-0`, oldest.id]);
+        expect(feed.map((e) => e.id)).toEqual([newest.id, `${middle.id}-0`, oldest.id]);
     });
 
     it('caps the feed at 40 events', () => {
@@ -186,6 +186,6 @@ describe('buildActivityFeed', () => {
             REPO,
         );
 
-        expect(feed.map(e => e.type)).toEqual(['pr', 'commit', 'branch']);
+        expect(feed.map((e) => e.type)).toEqual(['pr', 'commit', 'branch']);
     });
 });


### PR DESCRIPTION
## Summary
- New `server/api/github/activity.get.ts` endpoint: authenticates the user, resolves their GitHub App installation, and calls GitHub's Events API (`listRepoEvents`) to build a normalized activity feed (commit / PR / branch-create events, sorted newest-first, capped at 40).
- New `app/components/Github/ActivityTimeline.vue`: resolves the repo owner via the existing `/api/github/repos` lookup, fetches the feed, groups events by day (Today / Yesterday / date), and renders a dotted-rail timeline with per-event-type icon and tint.
- `app/pages/list/[id]/index.vue`: adds a 4th "Activity" view tab alongside List/Table/Board, shown only when the list has a `githubRepo` linked.

## Why
Implements the "GitHub Activity Timeline" design handoff. The repo has no persisted activity/event log (webhooks only mutate `Todos` status/links, nothing is stored as history), so this builds the feed live off GitHub's Events API per request rather than adding a new table — matches the scope of the design and avoids a schema migration for a read-only view.

## Notes for reviewer
- Owner isn't stored on `List` (only the repo name), so `ActivityTimeline.vue` resolves it via the same `/api/github/repos` → `full_name.split('/')` trick already used in `Github/Branch/Select.vue`.
- GitHub's Events API only surfaces the last ~90 days and collapses multiple commits in one push into a single timestamp — acceptable tradeoff for a lightweight, single-call feed; flagging in case a richer commit-level view is wanted later (would need `listCommits` + `pulls.list` merged instead).
- Timeline visuals use hardcoded hex + scoped `<style>` rather than only Vuetify props, matching the existing convention in `app/components/App/Nav/Mobile.vue` and `app/pages/list/[id]/index.vue` (needed to match the design's dot-rail look).
- `pnpm lint` is clean on all three changed/added files.

## Test plan
- [ ] Connect a GitHub repo to a list in list settings
- [ ] Open the list, confirm "Activity" tab appears
- [ ] Confirm commits/PRs/branch creations show grouped by day with correct icons and links
- [ ] Confirm tab is hidden for lists without a linked repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a GitHub Activity view for repository-linked lists.
  * Displayed commits, pull requests, and branch creation events in a newest-first timeline.
  * Added loading, error, and empty states with repository and event links.
  * Limited activity results to the 40 most recent events.
  * Excluded unsupported or incomplete activity entries for a cleaner timeline.

* **Tests**
  * Added coverage for activity types, filtering, sorting, and result limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->